### PR TITLE
PENV-271: split types and interfaces to different packages

### DIFF
--- a/etl/extractor/mainnet_impl.go
+++ b/etl/extractor/mainnet_impl.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/insolar/block-explorer/etl"
+	"github.com/insolar/block-explorer/etl/types"
 	"github.com/insolar/insolar/ledger/heavy/exporter"
 	"github.com/pkg/errors"
 )
@@ -20,7 +20,7 @@ type MainNetExtractor struct {
 
 	client           exporter.RecordExporterClient
 	request          *exporter.GetRecords
-	mainJetDropsChan chan *etl.PlatformJetDrops
+	mainJetDropsChan chan *types.PlatformJetDrops
 }
 
 func NewMainNetExtractor(batchSize uint32, exporterClient exporter.RecordExporterClient) *MainNetExtractor {
@@ -29,11 +29,11 @@ func NewMainNetExtractor(batchSize uint32, exporterClient exporter.RecordExporte
 		stopSignal:       make(chan bool, 1),
 		client:           exporterClient,
 		request:          request,
-		mainJetDropsChan: make(chan *etl.PlatformJetDrops),
+		mainJetDropsChan: make(chan *types.PlatformJetDrops),
 	}
 }
 
-func (m *MainNetExtractor) GetJetDrops(ctx context.Context) <-chan *etl.PlatformJetDrops {
+func (m *MainNetExtractor) GetJetDrops(ctx context.Context) <-chan *types.PlatformJetDrops {
 	// from pulse, 0 means start to get from pulse number 0
 	//todo: add pulse fetcher
 	m.request.PulseNumber = 0
@@ -84,7 +84,7 @@ func (m *MainNetExtractor) GetJetDrops(ctx context.Context) <-chan *etl.Platform
 				m.request.RecordNumber = resp.RecordNumber
 				m.request.PulseNumber = resp.Record.ID.Pulse()
 
-				jetDrops := new(etl.PlatformJetDrops)
+				jetDrops := new(types.PlatformJetDrops)
 				jetDrops.Records = append(jetDrops.Records, resp)
 				m.mainJetDropsChan <- jetDrops
 			}

--- a/etl/interfaces/interfaces.go
+++ b/etl/interfaces/interfaces.go
@@ -3,36 +3,37 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/block-explorer/blob/master/LICENSE.md.
 
-package etl
+package interfaces
 
 import (
 	"context"
 
+	"github.com/insolar/block-explorer/etl/types"
 	"google.golang.org/grpc"
 
 	"github.com/insolar/block-explorer/etl/models"
 )
 
-//go:generate minimock -i github.com/insolar/block-explorer/etl.Starter -o ./mock -s _mock.go -g
+//go:generate minimock -i github.com/insolar/block-explorer/etl/interfaces.Starter -o ./mock -s _mock.go -g
 type Starter interface {
 	// Start starts the main thread
 	Start(ctx context.Context) error
 }
 
-//go:generate minimock -i github.com/insolar/block-explorer/etl.Stopper -o ./mock -s _mock.go -g
+//go:generate minimock -i github.com/insolar/block-explorer/etl/interfaces.Stopper -o ./mock -s _mock.go -g
 type Stopper interface {
 	// Stops stops the main thread
 	Stop(ctx context.Context) error
 }
 
-//go:generate minimock -i github.com/insolar/block-explorer/etl.JetDropsExtractor -o ./mock -s _mock.go -g
+//go:generate minimock -i github.com/insolar/block-explorer/etl/interfaces.JetDropsExtractor -o ./mock -s _mock.go -g
 // JetDropsExtractor represents the main functions of working with Platform
 type JetDropsExtractor interface {
 	// GetJetDrops stores JetDrop data in the main JetDrop channel
-	GetJetDrops(ctx context.Context) <-chan *PlatformJetDrops
+	GetJetDrops(ctx context.Context) <-chan *types.PlatformJetDrops
 }
 
-//go:generate minimock -i github.com/insolar/block-explorer/etl.ConnectionManager -o ./mock -s _mock.go -g
+//go:generate minimock -i github.com/insolar/block-explorer/etl/interfaces.ConnectionManager -o ./mock -s _mock.go -g
 // ConnectionManager represents management of connection to Platform
 type ConnectionManager interface {
 	Starter
@@ -44,12 +45,12 @@ type Transformer interface {
 	Starter
 	Stopper
 	// transform transforms the row data to canonical data
-	transform(drop PlatformJetDrops) JetDrop
+	transform(drop types.PlatformJetDrops) types.JetDrop
 	// GetJetDropsChannel returns the channel where canonical data will be stored
-	GetJetDropsChannel() <-chan JetDrop
+	GetJetDropsChannel() <-chan types.JetDrop
 }
 
-//go:generate minimock -i github.com/insolar/block-explorer/etl.Client -o ./mock -s _mock.go -g
+//go:generate minimock -i github.com/insolar/block-explorer/etl/interfaces.Client -o ./mock -s _mock.go -g
 // Client represents a connection to the Platform
 type Client interface {
 	// GetGRPCConn returns a configured GRPC connection
@@ -60,16 +61,16 @@ type Client interface {
 type Processor interface {
 	Starter
 	Stopper
-	process(drop JetDrop)
+	process(drop types.JetDrop)
 }
 
-//go:generate minimock -i github.com/insolar/block-explorer/etl.Controller -o ./mock -s _mock.go -g
+//go:generate minimock -i github.com/insolar/block-explorer/etl/interfaces.Controller -o ./mock -s _mock.go -g
 // Controller tracks drops integrity and makes calls to reload data
 type Controller interface {
 	Starter
 	Stopper
 	// Save information about saved jetdrops
-	SetJetDropData(pulse Pulse, jetID []byte)
+	SetJetDropData(pulse types.Pulse, jetID []byte)
 }
 
 // Storage saves data to database

--- a/etl/interfaces/mock/client_mock.go
+++ b/etl/interfaces/mock/client_mock.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// ClientMock implements etl.Client
+// ClientMock implements interfaces.Client
 type ClientMock struct {
 	t minimock.Tester
 
@@ -21,7 +21,7 @@ type ClientMock struct {
 	GetGRPCConnMock          mClientMockGetGRPCConn
 }
 
-// NewClientMock returns a mock for etl.Client
+// NewClientMock returns a mock for interfaces.Client
 func NewClientMock(t minimock.Tester) *ClientMock {
 	m := &ClientMock{t: t}
 	if controller, ok := t.(minimock.MockController); ok {
@@ -103,7 +103,7 @@ func (mmGetGRPCConn *mClientMockGetGRPCConn) Set(f func() (cp1 *grpc.ClientConn)
 	return mmGetGRPCConn.mock
 }
 
-// GetGRPCConn implements etl.Client
+// GetGRPCConn implements interfaces.Client
 func (mmGetGRPCConn *ClientMock) GetGRPCConn() (cp1 *grpc.ClientConn) {
 	mm_atomic.AddUint64(&mmGetGRPCConn.beforeGetGRPCConnCounter, 1)
 	defer mm_atomic.AddUint64(&mmGetGRPCConn.afterGetGRPCConnCounter, 1)

--- a/etl/interfaces/mock/connection_manager_mock.go
+++ b/etl/interfaces/mock/connection_manager_mock.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gojuno/minimock/v3"
 )
 
-// ConnectionManagerMock implements etl.ConnectionManager
+// ConnectionManagerMock implements interfaces.ConnectionManager
 type ConnectionManagerMock struct {
 	t minimock.Tester
 
@@ -28,7 +28,7 @@ type ConnectionManagerMock struct {
 	StopMock          mConnectionManagerMockStop
 }
 
-// NewConnectionManagerMock returns a mock for etl.ConnectionManager
+// NewConnectionManagerMock returns a mock for interfaces.ConnectionManager
 func NewConnectionManagerMock(t minimock.Tester) *ConnectionManagerMock {
 	m := &ConnectionManagerMock{t: t}
 	if controller, ok := t.(minimock.MockController); ok {
@@ -150,7 +150,7 @@ func (e *ConnectionManagerMockStartExpectation) Then(err error) *ConnectionManag
 	return e.mock
 }
 
-// Start implements etl.ConnectionManager
+// Start implements interfaces.ConnectionManager
 func (mmStart *ConnectionManagerMock) Start(ctx context.Context) (err error) {
 	mm_atomic.AddUint64(&mmStart.beforeStartCounter, 1)
 	defer mm_atomic.AddUint64(&mmStart.afterStartCounter, 1)
@@ -365,7 +365,7 @@ func (e *ConnectionManagerMockStopExpectation) Then(err error) *ConnectionManage
 	return e.mock
 }
 
-// Stop implements etl.ConnectionManager
+// Stop implements interfaces.ConnectionManager
 func (mmStop *ConnectionManagerMock) Stop(ctx context.Context) (err error) {
 	mm_atomic.AddUint64(&mmStop.beforeStopCounter, 1)
 	defer mm_atomic.AddUint64(&mmStop.afterStopCounter, 1)

--- a/etl/interfaces/mock/controller_mock.go
+++ b/etl/interfaces/mock/controller_mock.go
@@ -9,15 +9,15 @@ import (
 	mm_time "time"
 
 	"github.com/gojuno/minimock/v3"
-	mm_etl "github.com/insolar/block-explorer/etl"
+	"github.com/insolar/block-explorer/etl/types"
 )
 
-// ControllerMock implements etl.Controller
+// ControllerMock implements interfaces.Controller
 type ControllerMock struct {
 	t minimock.Tester
 
-	funcSetJetDropData          func(pulse mm_etl.Pulse, jetID []byte)
-	inspectFuncSetJetDropData   func(pulse mm_etl.Pulse, jetID []byte)
+	funcSetJetDropData          func(pulse types.Pulse, jetID []byte)
+	inspectFuncSetJetDropData   func(pulse types.Pulse, jetID []byte)
 	afterSetJetDropDataCounter  uint64
 	beforeSetJetDropDataCounter uint64
 	SetJetDropDataMock          mControllerMockSetJetDropData
@@ -35,7 +35,7 @@ type ControllerMock struct {
 	StopMock          mControllerMockStop
 }
 
-// NewControllerMock returns a mock for etl.Controller
+// NewControllerMock returns a mock for interfaces.Controller
 func NewControllerMock(t minimock.Tester) *ControllerMock {
 	m := &ControllerMock{t: t}
 	if controller, ok := t.(minimock.MockController); ok {
@@ -73,12 +73,12 @@ type ControllerMockSetJetDropDataExpectation struct {
 
 // ControllerMockSetJetDropDataParams contains parameters of the Controller.SetJetDropData
 type ControllerMockSetJetDropDataParams struct {
-	pulse mm_etl.Pulse
+	pulse types.Pulse
 	jetID []byte
 }
 
 // Expect sets up expected params for Controller.SetJetDropData
-func (mmSetJetDropData *mControllerMockSetJetDropData) Expect(pulse mm_etl.Pulse, jetID []byte) *mControllerMockSetJetDropData {
+func (mmSetJetDropData *mControllerMockSetJetDropData) Expect(pulse types.Pulse, jetID []byte) *mControllerMockSetJetDropData {
 	if mmSetJetDropData.mock.funcSetJetDropData != nil {
 		mmSetJetDropData.mock.t.Fatalf("ControllerMock.SetJetDropData mock is already set by Set")
 	}
@@ -98,7 +98,7 @@ func (mmSetJetDropData *mControllerMockSetJetDropData) Expect(pulse mm_etl.Pulse
 }
 
 // Inspect accepts an inspector function that has same arguments as the Controller.SetJetDropData
-func (mmSetJetDropData *mControllerMockSetJetDropData) Inspect(f func(pulse mm_etl.Pulse, jetID []byte)) *mControllerMockSetJetDropData {
+func (mmSetJetDropData *mControllerMockSetJetDropData) Inspect(f func(pulse types.Pulse, jetID []byte)) *mControllerMockSetJetDropData {
 	if mmSetJetDropData.mock.inspectFuncSetJetDropData != nil {
 		mmSetJetDropData.mock.t.Fatalf("Inspect function is already set for ControllerMock.SetJetDropData")
 	}
@@ -122,7 +122,7 @@ func (mmSetJetDropData *mControllerMockSetJetDropData) Return() *ControllerMock 
 }
 
 //Set uses given function f to mock the Controller.SetJetDropData method
-func (mmSetJetDropData *mControllerMockSetJetDropData) Set(f func(pulse mm_etl.Pulse, jetID []byte)) *ControllerMock {
+func (mmSetJetDropData *mControllerMockSetJetDropData) Set(f func(pulse types.Pulse, jetID []byte)) *ControllerMock {
 	if mmSetJetDropData.defaultExpectation != nil {
 		mmSetJetDropData.mock.t.Fatalf("Default expectation is already set for the Controller.SetJetDropData method")
 	}
@@ -135,8 +135,8 @@ func (mmSetJetDropData *mControllerMockSetJetDropData) Set(f func(pulse mm_etl.P
 	return mmSetJetDropData.mock
 }
 
-// SetJetDropData implements etl.Controller
-func (mmSetJetDropData *ControllerMock) SetJetDropData(pulse mm_etl.Pulse, jetID []byte) {
+// SetJetDropData implements interfaces.Controller
+func (mmSetJetDropData *ControllerMock) SetJetDropData(pulse types.Pulse, jetID []byte) {
 	mm_atomic.AddUint64(&mmSetJetDropData.beforeSetJetDropDataCounter, 1)
 	defer mm_atomic.AddUint64(&mmSetJetDropData.afterSetJetDropDataCounter, 1)
 
@@ -348,7 +348,7 @@ func (e *ControllerMockStartExpectation) Then(err error) *ControllerMock {
 	return e.mock
 }
 
-// Start implements etl.Controller
+// Start implements interfaces.Controller
 func (mmStart *ControllerMock) Start(ctx context.Context) (err error) {
 	mm_atomic.AddUint64(&mmStart.beforeStartCounter, 1)
 	defer mm_atomic.AddUint64(&mmStart.afterStartCounter, 1)
@@ -563,7 +563,7 @@ func (e *ControllerMockStopExpectation) Then(err error) *ControllerMock {
 	return e.mock
 }
 
-// Stop implements etl.Controller
+// Stop implements interfaces.Controller
 func (mmStop *ControllerMock) Stop(ctx context.Context) (err error) {
 	mm_atomic.AddUint64(&mmStop.beforeStopCounter, 1)
 	defer mm_atomic.AddUint64(&mmStop.afterStopCounter, 1)

--- a/etl/interfaces/mock/jet_drops_extractor_mock.go
+++ b/etl/interfaces/mock/jet_drops_extractor_mock.go
@@ -9,21 +9,21 @@ import (
 	mm_time "time"
 
 	"github.com/gojuno/minimock/v3"
-	mm_etl "github.com/insolar/block-explorer/etl"
+	"github.com/insolar/block-explorer/etl/types"
 )
 
-// JetDropsExtractorMock implements etl.JetDropsExtractor
+// JetDropsExtractorMock implements interfaces.JetDropsExtractor
 type JetDropsExtractorMock struct {
 	t minimock.Tester
 
-	funcGetJetDrops          func(ctx context.Context) (ch1 <-chan *mm_etl.PlatformJetDrops)
+	funcGetJetDrops          func(ctx context.Context) (ch1 <-chan *types.PlatformJetDrops)
 	inspectFuncGetJetDrops   func(ctx context.Context)
 	afterGetJetDropsCounter  uint64
 	beforeGetJetDropsCounter uint64
 	GetJetDropsMock          mJetDropsExtractorMockGetJetDrops
 }
 
-// NewJetDropsExtractorMock returns a mock for etl.JetDropsExtractor
+// NewJetDropsExtractorMock returns a mock for interfaces.JetDropsExtractor
 func NewJetDropsExtractorMock(t minimock.Tester) *JetDropsExtractorMock {
 	m := &JetDropsExtractorMock{t: t}
 	if controller, ok := t.(minimock.MockController); ok {
@@ -60,7 +60,7 @@ type JetDropsExtractorMockGetJetDropsParams struct {
 
 // JetDropsExtractorMockGetJetDropsResults contains results of the JetDropsExtractor.GetJetDrops
 type JetDropsExtractorMockGetJetDropsResults struct {
-	ch1 <-chan *mm_etl.PlatformJetDrops
+	ch1 <-chan *types.PlatformJetDrops
 }
 
 // Expect sets up expected params for JetDropsExtractor.GetJetDrops
@@ -95,7 +95,7 @@ func (mmGetJetDrops *mJetDropsExtractorMockGetJetDrops) Inspect(f func(ctx conte
 }
 
 // Return sets up results that will be returned by JetDropsExtractor.GetJetDrops
-func (mmGetJetDrops *mJetDropsExtractorMockGetJetDrops) Return(ch1 <-chan *mm_etl.PlatformJetDrops) *JetDropsExtractorMock {
+func (mmGetJetDrops *mJetDropsExtractorMockGetJetDrops) Return(ch1 <-chan *types.PlatformJetDrops) *JetDropsExtractorMock {
 	if mmGetJetDrops.mock.funcGetJetDrops != nil {
 		mmGetJetDrops.mock.t.Fatalf("JetDropsExtractorMock.GetJetDrops mock is already set by Set")
 	}
@@ -108,7 +108,7 @@ func (mmGetJetDrops *mJetDropsExtractorMockGetJetDrops) Return(ch1 <-chan *mm_et
 }
 
 //Set uses given function f to mock the JetDropsExtractor.GetJetDrops method
-func (mmGetJetDrops *mJetDropsExtractorMockGetJetDrops) Set(f func(ctx context.Context) (ch1 <-chan *mm_etl.PlatformJetDrops)) *JetDropsExtractorMock {
+func (mmGetJetDrops *mJetDropsExtractorMockGetJetDrops) Set(f func(ctx context.Context) (ch1 <-chan *types.PlatformJetDrops)) *JetDropsExtractorMock {
 	if mmGetJetDrops.defaultExpectation != nil {
 		mmGetJetDrops.mock.t.Fatalf("Default expectation is already set for the JetDropsExtractor.GetJetDrops method")
 	}
@@ -137,13 +137,13 @@ func (mmGetJetDrops *mJetDropsExtractorMockGetJetDrops) When(ctx context.Context
 }
 
 // Then sets up JetDropsExtractor.GetJetDrops return parameters for the expectation previously defined by the When method
-func (e *JetDropsExtractorMockGetJetDropsExpectation) Then(ch1 <-chan *mm_etl.PlatformJetDrops) *JetDropsExtractorMock {
+func (e *JetDropsExtractorMockGetJetDropsExpectation) Then(ch1 <-chan *types.PlatformJetDrops) *JetDropsExtractorMock {
 	e.results = &JetDropsExtractorMockGetJetDropsResults{ch1}
 	return e.mock
 }
 
-// GetJetDrops implements etl.JetDropsExtractor
-func (mmGetJetDrops *JetDropsExtractorMock) GetJetDrops(ctx context.Context) (ch1 <-chan *mm_etl.PlatformJetDrops) {
+// GetJetDrops implements interfaces.JetDropsExtractor
+func (mmGetJetDrops *JetDropsExtractorMock) GetJetDrops(ctx context.Context) (ch1 <-chan *types.PlatformJetDrops) {
 	mm_atomic.AddUint64(&mmGetJetDrops.beforeGetJetDropsCounter, 1)
 	defer mm_atomic.AddUint64(&mmGetJetDrops.afterGetJetDropsCounter, 1)
 

--- a/etl/interfaces/mock/starter_mock.go
+++ b/etl/interfaces/mock/starter_mock.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gojuno/minimock/v3"
 )
 
-// StarterMock implements etl.Starter
+// StarterMock implements interfaces.Starter
 type StarterMock struct {
 	t minimock.Tester
 
@@ -22,7 +22,7 @@ type StarterMock struct {
 	StartMock          mStarterMockStart
 }
 
-// NewStarterMock returns a mock for etl.Starter
+// NewStarterMock returns a mock for interfaces.Starter
 func NewStarterMock(t minimock.Tester) *StarterMock {
 	m := &StarterMock{t: t}
 	if controller, ok := t.(minimock.MockController); ok {
@@ -141,7 +141,7 @@ func (e *StarterMockStartExpectation) Then(err error) *StarterMock {
 	return e.mock
 }
 
-// Start implements etl.Starter
+// Start implements interfaces.Starter
 func (mmStart *StarterMock) Start(ctx context.Context) (err error) {
 	mm_atomic.AddUint64(&mmStart.beforeStartCounter, 1)
 	defer mm_atomic.AddUint64(&mmStart.afterStartCounter, 1)

--- a/etl/interfaces/mock/stopper_mock.go
+++ b/etl/interfaces/mock/stopper_mock.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gojuno/minimock/v3"
 )
 
-// StopperMock implements etl.Stopper
+// StopperMock implements interfaces.Stopper
 type StopperMock struct {
 	t minimock.Tester
 
@@ -22,7 +22,7 @@ type StopperMock struct {
 	StopMock          mStopperMockStop
 }
 
-// NewStopperMock returns a mock for etl.Stopper
+// NewStopperMock returns a mock for interfaces.Stopper
 func NewStopperMock(t minimock.Tester) *StopperMock {
 	m := &StopperMock{t: t}
 	if controller, ok := t.(minimock.MockController); ok {
@@ -141,7 +141,7 @@ func (e *StopperMockStopExpectation) Then(err error) *StopperMock {
 	return e.mock
 }
 
-// Stop implements etl.Stopper
+// Stop implements interfaces.Stopper
 func (mmStop *StopperMock) Stop(ctx context.Context) (err error) {
 	mm_atomic.AddUint64(&mmStop.beforeStopCounter, 1)
 	defer mm_atomic.AddUint64(&mmStop.afterStopCounter, 1)

--- a/etl/types/types.go
+++ b/etl/types/types.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/block-explorer/blob/master/LICENSE.md.
 
-package etl
+package types
 
 import (
 	"time"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

we need to split types and interfaces to different packages because of cycle imports 

**- What I did**
split types and interfaces to different packages

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
