### PR TITLE
PENV-296: start extractor from current pulse number

### DIFF
--- a/cmd/block-explorer/main.go
+++ b/cmd/block-explorer/main.go
@@ -51,7 +51,8 @@ func main() {
 	}
 	defer client.GetGRPCConn().Close()
 
-	platformExtractor := extractor.NewPlatformExtractor(100, exporter.NewRecordExporterClient(client.GetGRPCConn()))
+	pulseExtractor := extractor.NewPlatformPulseExtractor(exporter.NewPulseExporterClient(client.GetGRPCConn()))
+	platformExtractor := extractor.NewPlatformExtractor(100, pulseExtractor, exporter.NewRecordExporterClient(client.GetGRPCConn()))
 	err = platformExtractor.Start(ctx)
 	if err != nil {
 		logger.Fatal("cannot start platformExtractor", err)

--- a/etl/extractor/extractor_bench_test.go
+++ b/etl/extractor/extractor_bench_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/insolar/block-explorer/configuration"
 	"github.com/insolar/block-explorer/etl/connection"
 	"github.com/insolar/block-explorer/testutils"
+	"github.com/insolar/block-explorer/testutils/clients"
 	"github.com/insolar/insolar/ledger/heavy/exporter"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +41,8 @@ func BenchmarkPlatformExtractorGetJetDrops(b *testing.B) {
 		require.NoError(b, err)
 
 		g := &RecordExporterClient{}
-		extractor := NewPlatformExtractor(uint32(defaultLocalBatchSize), g)
+		pulseClient := clients.GetTestPulseClient(1, nil)
+		extractor := NewPlatformExtractor(uint32(defaultLocalBatchSize), NewPlatformPulseExtractor(pulseClient), g)
 		err = extractor.Start(ctx)
 		require.NoError(b, err)
 

--- a/etl/extractor/extractor_bench_test.go
+++ b/etl/extractor/extractor_bench_test.go
@@ -40,9 +40,8 @@ func BenchmarkPlatformExtractorGetJetDrops(b *testing.B) {
 		client, err := connection.NewGRPCClientConnection(ctx, cfg)
 		require.NoError(b, err)
 
-		g := &RecordExporterClient{}
 		pulseClient := clients.GetTestPulseClient(1, nil)
-		extractor := NewPlatformExtractor(uint32(defaultLocalBatchSize), NewPlatformPulseExtractor(pulseClient), g)
+		extractor := NewPlatformExtractor(uint32(defaultLocalBatchSize), NewPlatformPulseExtractor(pulseClient), &RecordExporterClient{})
 		err = extractor.Start(ctx)
 		require.NoError(b, err)
 

--- a/etl/extractor/platform_integration_test.go
+++ b/etl/extractor/platform_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/insolar/block-explorer/configuration"
 	"github.com/insolar/block-explorer/etl/connection"
 	"github.com/insolar/block-explorer/testutils"
+	"github.com/insolar/block-explorer/testutils/clients"
 	"github.com/insolar/insolar/ledger/heavy/exporter"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +39,8 @@ func TestExporterIsWorking(t *testing.T) {
 	defer client.GetGRPCConn().Close()
 
 	g := &RecordExporterClient{}
-	extractor := NewPlatformExtractor(uint32(defaultLocalBatchSize), g)
+	pulseClient := clients.GetTestPulseClient(1, nil)
+	extractor := NewPlatformExtractor(uint32(defaultLocalBatchSize), NewPlatformPulseExtractor(pulseClient), g)
 	err = extractor.Start(ctx)
 	require.NoError(t, err)
 	defer extractor.Stop(ctx)

--- a/etl/extractor/platform_pulse_test.go
+++ b/etl/extractor/platform_pulse_test.go
@@ -12,21 +12,14 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/insolar/insolar/ledger/heavy/exporter"
+	"github.com/insolar/block-explorer/testutils/clients"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 func TestPulse_getCurrentPulse_Success(t *testing.T) {
 	ctx := context.Background()
 	expectedPulse := uint32(0)
-	client := &pulseClient{}
-	client.topSyncPulse = func(ctx context.Context, in *exporter.GetTopSyncPulse, opts ...grpc.CallOption) (response *exporter.TopSyncPulseResponse, e error) {
-		return &exporter.TopSyncPulseResponse{
-			Polymorph:   0,
-			PulseNumber: expectedPulse,
-		}, nil
-	}
+	client := clients.GetTestPulseClient(expectedPulse, nil)
 
 	pe := NewPlatformPulseExtractor(client)
 	currentPulse, err := pe.GetCurrentPulse(ctx)
@@ -36,28 +29,9 @@ func TestPulse_getCurrentPulse_Success(t *testing.T) {
 
 func TestPulse_getCurrentPulse_Fail(t *testing.T) {
 	ctx := context.Background()
-	client := &pulseClient{}
-	client.topSyncPulse = func(ctx context.Context, in *exporter.GetTopSyncPulse, opts ...grpc.CallOption) (response *exporter.TopSyncPulseResponse, e error) {
-		return &exporter.TopSyncPulseResponse{
-			Polymorph:   0,
-			PulseNumber: 1,
-		}, errors.New("test error")
-	}
+	client := clients.GetTestPulseClient(1, errors.New("test error"))
 
 	pe := NewPlatformPulseExtractor(client)
 	_, err := pe.GetCurrentPulse(ctx)
 	require.Error(t, err)
-}
-
-type pulseClient struct {
-	export       func(ctx context.Context, in *exporter.GetPulses, opts ...grpc.CallOption) (exporter.PulseExporter_ExportClient, error)
-	topSyncPulse func(ctx context.Context, in *exporter.GetTopSyncPulse, opts ...grpc.CallOption) (*exporter.TopSyncPulseResponse, error)
-}
-
-func (c *pulseClient) Export(ctx context.Context, in *exporter.GetPulses, opts ...grpc.CallOption) (exporter.PulseExporter_ExportClient, error) {
-	return c.export(ctx, in, opts...)
-}
-
-func (c *pulseClient) TopSyncPulse(ctx context.Context, in *exporter.GetTopSyncPulse, opts ...grpc.CallOption) (*exporter.TopSyncPulseResponse, error) {
-	return c.topSyncPulse(ctx, in, opts...)
 }

--- a/testutils/betestsetup/betestsetup.go
+++ b/testutils/betestsetup/betestsetup.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/insolar/block-explorer/configuration"
+	"github.com/insolar/block-explorer/testutils/clients"
 
 	"github.com/insolar/block-explorer/etl/controller"
 	"github.com/insolar/block-explorer/etl/extractor"
@@ -46,7 +47,9 @@ var cfg = configuration.Controller{PulsePeriod: 10}
 func (b *BlockExplorerTestSetUp) Start() error {
 	b.ctx = context.Background()
 
-	b.extr = extractor.NewPlatformExtractor(100, b.ExporterClient)
+	pulseClient := clients.GetTestPulseClient(1, nil)
+	pulseExtractor := extractor.NewPlatformPulseExtractor(pulseClient)
+	b.extr = extractor.NewPlatformExtractor(100, pulseExtractor, b.ExporterClient)
 	err := b.extr.Start(b.ctx)
 	if err != nil {
 		return err

--- a/testutils/clients/pulse_client.go
+++ b/testutils/clients/pulse_client.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/block-explorer/blob/master/LICENSE.md.
+
+package clients
+
+import (
+	"context"
+
+	"github.com/insolar/insolar/ledger/heavy/exporter"
+	"google.golang.org/grpc"
+)
+
+type TestPulseClient struct {
+	export       func(ctx context.Context, in *exporter.GetPulses, opts ...grpc.CallOption) (exporter.PulseExporter_ExportClient, error)
+	topSyncPulse func(ctx context.Context, in *exporter.GetTopSyncPulse, opts ...grpc.CallOption) (*exporter.TopSyncPulseResponse, error)
+}
+
+func (c *TestPulseClient) Export(ctx context.Context, in *exporter.GetPulses, opts ...grpc.CallOption) (exporter.PulseExporter_ExportClient, error) {
+	return c.export(ctx, in, opts...)
+}
+
+func (c *TestPulseClient) TopSyncPulse(ctx context.Context, in *exporter.GetTopSyncPulse, opts ...grpc.CallOption) (*exporter.TopSyncPulseResponse, error) {
+	return c.topSyncPulse(ctx, in, opts...)
+}
+
+func getTestTopSyncPulseResponse(pn uint32) *exporter.TopSyncPulseResponse {
+	return &exporter.TopSyncPulseResponse{
+		Polymorph:   0,
+		PulseNumber: pn,
+	}
+}
+
+func GetTestPulseClient(pn uint32, err error) *TestPulseClient {
+	client := &TestPulseClient{}
+	client.topSyncPulse = func(ctx context.Context, in *exporter.GetTopSyncPulse, opts ...grpc.CallOption) (response *exporter.TopSyncPulseResponse, e error) {
+		return getTestTopSyncPulseResponse(pn), err
+	}
+	return client
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
BE have to start works from current pulse number. That's why we need to pass a function which returns pn 
**- What I did**
start working from the current pulse number
add test pulse extractor which imitates real pulse extractor 

**- How I did it**
pass interface to NewPlatformExtractor
**- How to verify it**
with tests and on the real testnet 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
