### PR TITLE
Penv-414: pulse_number as int64

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -157,10 +157,11 @@ func (s *Server) JetDropsByJetID(ctx echo.Context, jetID server.JetIdPath, param
 		failures = append(failures, validationError...)
 	}
 
-	var pulseNumberLte, pulseNumberLt, pulseNumberGte, pulseNumberGt *int
+	var pulseNumberLte, pulseNumberLt, pulseNumberGte, pulseNumberGt *int64
 	if params.PulseNumberGt != nil {
 		unptr := int(*params.PulseNumberGt)
-		pulseNumberGt = &unptr
+		_int64 := int64(unptr)
+		pulseNumberGt = &_int64
 		if !pulse.IsValidAsPulseNumber(unptr) {
 			failures = append(failures, server.CodeValidationFailures{
 				FailureReason: NullableString("invalid value"),
@@ -171,7 +172,8 @@ func (s *Server) JetDropsByJetID(ctx echo.Context, jetID server.JetIdPath, param
 
 	if params.PulseNumberGte != nil {
 		unptr := int(*params.PulseNumberGte)
-		pulseNumberGte = &unptr
+		_int64 := int64(unptr)
+		pulseNumberGte = &_int64
 		if !pulse.IsValidAsPulseNumber(unptr) {
 			failures = append(failures, server.CodeValidationFailures{
 				FailureReason: NullableString("invalid value"),
@@ -182,7 +184,8 @@ func (s *Server) JetDropsByJetID(ctx echo.Context, jetID server.JetIdPath, param
 
 	if params.PulseNumberLt != nil {
 		unptr := int(*params.PulseNumberLt)
-		pulseNumberLt = &unptr
+		_int64 := int64(unptr)
+		pulseNumberLt = &_int64
 		if !pulse.IsValidAsPulseNumber(unptr) {
 			failures = append(failures, server.CodeValidationFailures{
 				FailureReason: NullableString("invalid value"),
@@ -193,7 +196,8 @@ func (s *Server) JetDropsByJetID(ctx echo.Context, jetID server.JetIdPath, param
 
 	if params.PulseNumberLte != nil {
 		unptr := int(*params.PulseNumberLte)
-		pulseNumberLte = &unptr
+		_int64 := int64(unptr)
+		pulseNumberLte = &_int64
 		if !pulse.IsValidAsPulseNumber(unptr) {
 			failures = append(failures, server.CodeValidationFailures{
 				FailureReason: NullableString("invalid value"),
@@ -241,8 +245,8 @@ func (s *Server) Pulses(ctx echo.Context, params server.PulsesParams) error {
 	limit, offset, failures := checkLimitOffset(params.Limit, params.Offset)
 
 	var fromPulseString *int64
-	var timestampLte *int
-	var timestampGte *int
+	var timestampLte *int64
+	var timestampGte *int64
 
 	if params.FromPulseNumber != nil {
 		i := int64(*params.FromPulseNumber)
@@ -265,11 +269,11 @@ func (s *Server) Pulses(ctx echo.Context, params server.PulsesParams) error {
 	}
 
 	if params.TimestampLte != nil {
-		str := int(*params.TimestampLte)
+		str := int64(*params.TimestampLte)
 		timestampLte = &str
 	}
 	if params.TimestampGte != nil {
-		str := int(*params.TimestampGte)
+		str := int64(*params.TimestampGte)
 		timestampGte = &str
 	}
 
@@ -300,7 +304,7 @@ func (s *Server) Pulses(ctx echo.Context, params server.PulsesParams) error {
 }
 
 func (s *Server) Pulse(ctx echo.Context, pulseNumber server.PulseNumberPath) error {
-	pulse, jetDropAmount, recordAmount, err := s.storage.GetPulse(int(pulseNumber))
+	pulse, jetDropAmount, recordAmount, err := s.storage.GetPulse(int64(pulseNumber))
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
 			return ctx.JSON(http.StatusNotFound, struct{}{})
@@ -347,7 +351,7 @@ func (s *Server) JetDropsByPulseNumber(ctx echo.Context, pulseNumber server.Puls
 	}
 
 	jetDrops, total, err := s.storage.GetJetDropsWithParams(
-		models.Pulse{PulseNumber: int(pulseNumber)},
+		models.Pulse{PulseNumber: int64(pulseNumber)},
 		exporterJetDropID,
 		limit,
 		offset,
@@ -494,10 +498,10 @@ func (s *Server) ObjectLifeline(ctx echo.Context, objectReference server.ObjectR
 	}
 
 	var fromIndexString *string
-	var pulseNumberLtString *int
-	var pulseNumberGtString *int
-	var timestampLteString *int
-	var timestampGteString *int
+	var pulseNumberLt *int64
+	var pulseNumberGt *int64
+	var timestampLte *int64
+	var timestampGte *int64
 
 	if params.FromIndex != nil {
 		str := string(*params.FromIndex)
@@ -511,9 +515,10 @@ func (s *Server) ObjectLifeline(ctx echo.Context, objectReference server.ObjectR
 		}
 	}
 	if params.PulseNumberLt != nil {
-		str := int(*params.PulseNumberLt)
-		pulseNumberLtString = &str
-		if !pulse.IsValidAsPulseNumber(str) {
+		unptr := int(*params.PulseNumberLt)
+		_int64 := int64(unptr)
+		pulseNumberLt = &_int64
+		if !pulse.IsValidAsPulseNumber(unptr) {
 			failures = append(failures, server.CodeValidationFailures{
 				FailureReason: NullableString("invalid"),
 				Property:      NullableString("pulse_number_lt"),
@@ -521,9 +526,10 @@ func (s *Server) ObjectLifeline(ctx echo.Context, objectReference server.ObjectR
 		}
 	}
 	if params.PulseNumberGt != nil {
-		str := int(*params.PulseNumberGt)
-		pulseNumberGtString = &str
-		if !pulse.IsValidAsPulseNumber(str) {
+		unptr := int(*params.PulseNumberGt)
+		_int64 := int64(unptr)
+		pulseNumberGt = &_int64
+		if !pulse.IsValidAsPulseNumber(unptr) {
 			failures = append(failures, server.CodeValidationFailures{
 				FailureReason: NullableString("invalid"),
 				Property:      NullableString("pulse_number_gt"),
@@ -541,19 +547,19 @@ func (s *Server) ObjectLifeline(ctx echo.Context, objectReference server.ObjectR
 	}
 
 	if params.TimestampLte != nil {
-		str := int(*params.TimestampLte)
-		timestampLteString = &str
+		unptr := int64(*params.TimestampLte)
+		pulseNumberGt = &unptr
 	}
 	if params.TimestampGte != nil {
-		str := int(*params.TimestampGte)
-		timestampGteString = &str
+		unptr := int64(*params.TimestampGte)
+		timestampGte = &unptr
 	}
 
 	records, count, err := s.storage.GetLifeline(
 		ref.GetLocal().Bytes(),
 		fromIndexString,
-		pulseNumberLtString, pulseNumberGtString,
-		timestampLteString, timestampGteString,
+		pulseNumberLt, pulseNumberGt,
+		timestampLte, timestampGte,
 		limit, offset,
 		sortByIndexAsc,
 	)

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -651,7 +651,7 @@ func TestServer_JetDropsByPulseNumber(t *testing.T) {
 		err = testutils.CreateJetDrop(testDB, jetDrop3)
 		require.NoError(t, err)
 
-		resp, err := http.Get("http://" + apihost + "/api/v1/pulses/" + strconv.Itoa(pulse.PulseNumber) + "/jet-drops")
+		resp, err := http.Get("http://" + apihost + "/api/v1/pulses/" + strconv.FormatInt(pulse.PulseNumber, 10) + "/jet-drops")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
@@ -663,9 +663,9 @@ func TestServer_JetDropsByPulseNumber(t *testing.T) {
 		require.EqualValues(t, 3, int(*received.Total))
 		require.Len(t, *received.Result, 3)
 		// check asc order by default
-		require.Equal(t, models.NewJetDropID(jetDrop1.JetID, int64(pulse.PulseNumber)).ToString(), *(*received.Result)[0].JetDropId)
-		require.Equal(t, models.NewJetDropID(jetDrop2.JetID, int64(pulse.PulseNumber)).ToString(), *(*received.Result)[1].JetDropId)
-		require.Equal(t, models.NewJetDropID(jetDrop3.JetID, int64(pulse.PulseNumber)).ToString(), *(*received.Result)[2].JetDropId)
+		require.Equal(t, models.NewJetDropID(jetDrop1.JetID, pulse.PulseNumber).ToString(), *(*received.Result)[0].JetDropId)
+		require.Equal(t, models.NewJetDropID(jetDrop2.JetID, pulse.PulseNumber).ToString(), *(*received.Result)[1].JetDropId)
+		require.Equal(t, models.NewJetDropID(jetDrop3.JetID, pulse.PulseNumber).ToString(), *(*received.Result)[2].JetDropId)
 	})
 
 	t.Run("happy with limit", func(t *testing.T) {
@@ -694,7 +694,7 @@ func TestServer_JetDropsByPulseNumber(t *testing.T) {
 		err = testutils.CreateJetDrop(testDB, jetDrop3)
 		require.NoError(t, err)
 
-		resp, err := http.Get("http://" + apihost + "/api/v1/pulses/" + strconv.Itoa(pulse.PulseNumber) + "/jet-drops?limit=2")
+		resp, err := http.Get("http://" + apihost + "/api/v1/pulses/" + strconv.FormatInt(pulse.PulseNumber, 10) + "/jet-drops?limit=2")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
@@ -757,7 +757,7 @@ func TestServer_JetDropsByPulseNumber(t *testing.T) {
 
 		resp, err := http.Get(
 			"http://" + apihost + "/api/v1/pulses/" +
-				strconv.Itoa(pulse.PulseNumber) +
+				strconv.FormatInt(pulse.PulseNumber, 10) +
 				"/jet-drops?limit=2&offset=2&from_jet_drop_id=" +
 				jetDropID3,
 		)
@@ -781,7 +781,7 @@ func TestServer_JetDropsByPulseNumber(t *testing.T) {
 		require.NoError(t, err)
 		resp, err := http.Get(
 			"http://" + apihost + "/api/v1/pulses/" +
-				strconv.Itoa(pulse.PulseNumber) +
+				strconv.FormatInt(pulse.PulseNumber, 10) +
 				"/jet-drops?from_jet_drop_id=" +
 				"test",
 		)
@@ -801,7 +801,7 @@ func TestServer_JetDropsByPulseNumber(t *testing.T) {
 
 		resp, err = http.Get(
 			"http://" + apihost + "/api/v1/pulses/" +
-				strconv.Itoa(pulse.PulseNumber) +
+				strconv.FormatInt(pulse.PulseNumber, 10) +
 				"/jet-drops?from_jet_drop_id=" +
 				"10076767676",
 		)
@@ -820,7 +820,7 @@ func TestServer_JetDropsByPulseNumber(t *testing.T) {
 
 		resp, err = http.Get(
 			"http://" + apihost + "/api/v1/pulses/" +
-				strconv.Itoa(pulse.PulseNumber) +
+				strconv.FormatInt(pulse.PulseNumber, 10) +
 				"/jet-drops?from_jet_drop_id=" +
 				"76767676:1000",
 		)
@@ -897,7 +897,7 @@ func TestServer_JetDropsByPulseNumber(t *testing.T) {
 		require.NoError(t, err)
 		resp, err := http.Get(
 			"http://" + apihost + "/api/v1/pulses/" +
-				strconv.Itoa(pulse.PulseNumber) +
+				strconv.FormatInt(pulse.PulseNumber, 10) +
 				"/jet-drops?limit=" + "we248934h9h'`;",
 		)
 		require.NoError(t, err)
@@ -1350,7 +1350,7 @@ func TestServer_JetDropsByJetID(t *testing.T) {
 
 	t.Run("pulseNumberLte", func(t *testing.T) {
 		expectedCount := 2
-		pulseNumberLte := strconv.Itoa(preparedPulses[1].PulseNumber)
+		pulseNumberLte := strconv.FormatInt(preparedPulses[1].PulseNumber, 10)
 		resp, err := http.Get("http://" + apihost + "/api/v1/jets/" + jetID + "/jet-drops?pulse_number_lte=" + pulseNumberLte)
 		response := checkOkReturningResponse(t, resp, err)
 
@@ -1364,7 +1364,7 @@ func TestServer_JetDropsByJetID(t *testing.T) {
 	})
 	t.Run("pulseNumberLte-all", func(t *testing.T) {
 		expectedCount := totalCount
-		pulseNumberLte := strconv.Itoa(preparedPulses[totalCount-1].PulseNumber)
+		pulseNumberLte := strconv.FormatInt(preparedPulses[totalCount-1].PulseNumber, 10)
 		resp, err := http.Get("http://" + apihost + "/api/v1/jets/" + jetID + "/jet-drops?pulse_number_lte=" + pulseNumberLte)
 		response := checkOkReturningResponse(t, resp, err)
 
@@ -1378,7 +1378,7 @@ func TestServer_JetDropsByJetID(t *testing.T) {
 	})
 	t.Run("pulseNumberLt", func(t *testing.T) {
 		expectedCount := 1
-		pulseNumberLte := strconv.Itoa(preparedPulses[1].PulseNumber)
+		pulseNumberLte := strconv.FormatInt(preparedPulses[1].PulseNumber, 10)
 		resp, err := http.Get("http://" + apihost + "/api/v1/jets/" + jetID + "/jet-drops?pulse_number_lt=" + pulseNumberLte)
 		response := checkOkReturningResponse(t, resp, err)
 
@@ -1392,7 +1392,7 @@ func TestServer_JetDropsByJetID(t *testing.T) {
 	})
 	t.Run("pulseNumberLt-no-one", func(t *testing.T) {
 		expectedCount := 0
-		pulseNumberLt := strconv.Itoa(preparedPulses[0].PulseNumber)
+		pulseNumberLt := strconv.FormatInt(preparedPulses[0].PulseNumber, 10)
 		resp, err := http.Get("http://" + apihost + "/api/v1/jets/" + jetID + "/jet-drops?pulse_number_lt=" + pulseNumberLt)
 		response := checkOkReturningResponse(t, resp, err)
 
@@ -1401,7 +1401,7 @@ func TestServer_JetDropsByJetID(t *testing.T) {
 	})
 	t.Run("pulseNumberGte", func(t *testing.T) {
 		expectedCount := totalCount - 1
-		pulseNumberGte := strconv.Itoa(preparedPulses[1].PulseNumber)
+		pulseNumberGte := strconv.FormatInt(preparedPulses[1].PulseNumber, 10)
 		resp, err := http.Get("http://" + apihost + "/api/v1/jets/" + jetID + "/jet-drops?pulse_number_gte=" + pulseNumberGte)
 		response := checkOkReturningResponse(t, resp, err)
 
@@ -1415,7 +1415,7 @@ func TestServer_JetDropsByJetID(t *testing.T) {
 	})
 	t.Run("pulseNumberGte-all", func(t *testing.T) {
 		expectedCount := totalCount
-		pulseNumberGte := strconv.Itoa(preparedPulses[0].PulseNumber)
+		pulseNumberGte := strconv.FormatInt(preparedPulses[0].PulseNumber, 10)
 		resp, err := http.Get("http://" + apihost + "/api/v1/jets/" + jetID + "/jet-drops?pulse_number_gte=" + pulseNumberGte)
 		response := checkOkReturningResponse(t, resp, err)
 
@@ -1429,7 +1429,7 @@ func TestServer_JetDropsByJetID(t *testing.T) {
 	})
 	t.Run("pulseNumberGt", func(t *testing.T) {
 		expectedCount := totalCount - 2
-		pulseNumberGt := strconv.Itoa(preparedPulses[1].PulseNumber)
+		pulseNumberGt := strconv.FormatInt(preparedPulses[1].PulseNumber, 10)
 		resp, err := http.Get("http://" + apihost + "/api/v1/jets/" + jetID + "/jet-drops?pulse_number_gt=" + pulseNumberGt)
 		response := checkOkReturningResponse(t, resp, err)
 
@@ -1443,7 +1443,7 @@ func TestServer_JetDropsByJetID(t *testing.T) {
 	})
 	t.Run("pulseNumberGt-no-one", func(t *testing.T) {
 		expectedCount := 0
-		pulseNumberGt := strconv.Itoa(preparedPulses[totalCount-1].PulseNumber)
+		pulseNumberGt := strconv.FormatInt(preparedPulses[totalCount-1].PulseNumber, 10)
 		resp, err := http.Get("http://" + apihost + "/api/v1/jets/" + jetID + "/jet-drops?pulse_number_gt=" + pulseNumberGt)
 		received := checkOkReturningResponse(t, resp, err)
 

--- a/api/mappers.go
+++ b/api/mappers.go
@@ -59,9 +59,9 @@ func RecordToAPI(record models.Record) server.Record {
 }
 
 func PulseToAPI(pulse models.Pulse, jetDropAmount, recordAmount int64) server.Pulse {
-	pulseNumber := int64(pulse.PulseNumber)
-	prevPulseNumber := int64(pulse.PrevPulseNumber)
-	nextPulseNumber := int64(pulse.NextPulseNumber)
+	pulseNumber := pulse.PulseNumber
+	prevPulseNumber := pulse.PrevPulseNumber
+	nextPulseNumber := pulse.NextPulseNumber
 	response := server.Pulse{
 		IsComplete:      &pulse.IsComplete,
 		JetDropAmount:   &jetDropAmount,

--- a/api/mappers.go
+++ b/api/mappers.go
@@ -21,7 +21,7 @@ func NullableString(s string) *string {
 }
 
 func RecordToAPI(record models.Record) server.Record {
-	pulseNumber := int64(record.PulseNumber)
+	pulseNumber := record.PulseNumber
 	jetDropID := models.NewJetDropID(record.JetID, pulseNumber)
 	response := server.Record{
 		Hash:        NullableString(base64.StdEncoding.EncodeToString(record.Hash)),
@@ -75,7 +75,7 @@ func PulseToAPI(pulse models.Pulse, jetDropAmount, recordAmount int64) server.Pu
 }
 
 func JetDropToAPI(jetDrop models.JetDrop) server.JetDrop {
-	pulseNumber := int64(jetDrop.PulseNumber)
+	pulseNumber := jetDrop.PulseNumber
 	recordAmount := int64(jetDrop.RecordAmount)
 	// TODO: set correct prev and next after PENV-348
 	nextJetDropID := []server.NextPrevJetDrop{{
@@ -84,7 +84,7 @@ func JetDropToAPI(jetDrop models.JetDrop) server.JetDrop {
 	}}
 	prevJetDropID := []server.NextPrevJetDrop{{}}
 
-	jetDropID := models.NewJetDropID(jetDrop.JetID, int64(jetDrop.PulseNumber))
+	jetDropID := models.NewJetDropID(jetDrop.JetID, jetDrop.PulseNumber)
 	result := server.JetDrop{
 		Hash:      NullableString(base64.StdEncoding.EncodeToString(jetDrop.Hash)),
 		JetDropId: NullableString(jetDropID.ToString()),

--- a/etl/connection/grpc_client_test.go
+++ b/etl/connection/grpc_client_test.go
@@ -25,7 +25,7 @@ func TestNewClient_readyToConnect(t *testing.T) {
 
 func testConfig() configuration.Replicator {
 	return configuration.Replicator{
-		Addr:            "127.0.0.1:5678",
+		Addr:            "127.0.0.1:0",
 		MaxTransportMsg: 1073741824,
 	}
 }

--- a/etl/controller/controller_test.go
+++ b/etl/controller/controller_test.go
@@ -41,7 +41,7 @@ func TestNewController_NoPulses(t *testing.T) {
 func TestNewController_OneNotCompletePulse(t *testing.T) {
 	extractor := mock.NewJetDropsExtractorMock(t)
 
-	pulseNumber := 1
+	pulseNumber := int64(1)
 	firstJetID := "123"
 	secondJetID := "345"
 	expectedData := map[types.Pulse][]string{{PulseNo: pulseNumber}: {firstJetID, secondJetID}}
@@ -65,8 +65,8 @@ func TestNewController_OneNotCompletePulse(t *testing.T) {
 func TestNewController_SeveralNotCompletePulses(t *testing.T) {
 	extractor := mock.NewJetDropsExtractorMock(t)
 
-	firstPulseNumber := 1
-	secondPulseNumber := 2
+	firstPulseNumber := int64(1)
+	secondPulseNumber := int64(2)
 	firstJetID := "123"
 	secondJetID := "345"
 	firstPulse := types.Pulse{PulseNo: firstPulseNumber}
@@ -116,7 +116,7 @@ func TestNewController_ErrorGetPulses(t *testing.T) {
 func TestNewController_ErrorGetJetDrops(t *testing.T) {
 	extractor := mock.NewJetDropsExtractorMock(t)
 
-	pulseNumber := 1
+	pulseNumber := int64(1)
 
 	sm := mock.NewStorageMock(t)
 	sm.GetIncompletePulsesMock.Return([]models.Pulse{{PulseNumber: pulseNumber}}, nil)

--- a/etl/controller/misseddata.go
+++ b/etl/controller/misseddata.go
@@ -15,8 +15,8 @@ import (
 
 type missedData struct {
 	ts        time.Time
-	fromPulse int
-	toPulse   int
+	fromPulse int64
+	toPulse   int64
 }
 
 // MissedDataManager manages working with missed data pool
@@ -60,7 +60,7 @@ func (mdm *MissedDataManager) Stop() {
 }
 
 // Add adds missed data to pool
-func (mdm *MissedDataManager) Add(ctx context.Context, fromPulse, toPulse int) bool {
+func (mdm *MissedDataManager) Add(ctx context.Context, fromPulse, toPulse int64) bool {
 	mdm.mutex.Lock()
 	defer mdm.mutex.Unlock()
 

--- a/etl/controller/pulsemaintainer.go
+++ b/etl/controller/pulsemaintainer.go
@@ -104,7 +104,7 @@ func pulseIsComplete(p types.Pulse, d []string) bool { // nolint
 	return p.PulseNo >= 0
 }
 
-func (c *Controller) reloadData(ctx context.Context, fromPulseNumber int, toPulseNumber int) {
+func (c *Controller) reloadData(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) {
 	log := belogger.FromContext(ctx)
 	if c.missedDataManager.Add(ctx, fromPulseNumber, toPulseNumber) {
 		err := c.extractor.LoadJetDrops(ctx, fromPulseNumber, toPulseNumber)

--- a/etl/controller/pulsemaintainer_test.go
+++ b/etl/controller/pulsemaintainer_test.go
@@ -68,44 +68,44 @@ func TestController_pulseSequence_StartFromNothing(t *testing.T) {
 			wg.Done()
 		}
 		if sm.GetPulseByPrevBeforeCounter() == 1 || sm.GetPulseByPrevBeforeCounter() == 2 {
-			require.Equal(t, 0, prevPulse.PulseNumber)
+			require.Equal(t, int64(0), prevPulse.PulseNumber)
 			return models.Pulse{}, nil
 		}
 		if sm.GetPulseByPrevBeforeCounter() == 3 {
-			require.Equal(t, 0, prevPulse.PulseNumber)
+			require.Equal(t, int64(0), prevPulse.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 0, PulseNumber: pulse.MinTimePulse, NextPulseNumber: 1000000, IsComplete: false}, nil
 		}
 		if sm.GetPulseByPrevBeforeCounter() == 4 {
-			require.Equal(t, 0, prevPulse.PulseNumber)
+			require.Equal(t, int64(0), prevPulse.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 0, PulseNumber: pulse.MinTimePulse, NextPulseNumber: 1000000, IsComplete: true}, nil
 		}
-		require.Equal(t, pulse.MinTimePulse, prevPulse.PulseNumber)
+		require.Equal(t, int64(pulse.MinTimePulse), prevPulse.PulseNumber)
 		return models.Pulse{}, nil
 	})
 	sm.GetNextSavedPulseMock.Set(func(fromPulseNumber models.Pulse) (p1 models.Pulse, err error) {
 		if sm.GetNextSavedPulseBeforeCounter() == 1 || sm.GetPulseByPrevBeforeCounter() == 2 {
-			require.Equal(t, 0, fromPulseNumber.PulseNumber)
+			require.Equal(t, int64(0), fromPulseNumber.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 1000100, PulseNumber: 1000110, NextPulseNumber: 1000120}, nil
 		}
 		if sm.GetNextSavedPulseBeforeCounter() == 3 {
-			require.Equal(t, pulse.MinTimePulse, fromPulseNumber.PulseNumber)
+			require.Equal(t, int64(pulse.MinTimePulse), fromPulseNumber.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 1000100, PulseNumber: 1000110, NextPulseNumber: 1000120}, nil
 		}
-		require.Equal(t, pulse.MinTimePulse, fromPulseNumber.PulseNumber)
+		require.Equal(t, int64(pulse.MinTimePulse), fromPulseNumber.PulseNumber)
 		return models.Pulse{}, nil
 	})
-	extractor.LoadJetDropsMock.Set(func(ctx context.Context, fromPulseNumber int, toPulseNumber int) (err error) {
+	extractor.LoadJetDropsMock.Set(func(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) (err error) {
 		if extractor.LoadJetDropsBeforeCounter() == 1 {
-			require.Equal(t, 0, fromPulseNumber)
-			require.Equal(t, 1000110, toPulseNumber)
+			require.Equal(t, int64(0), fromPulseNumber)
+			require.Equal(t, int64(1000110), toPulseNumber)
 		} else {
 			require.Fail(t, "LoadJetDrops was called more than once")
 		}
 		return nil
 	})
-	sm.SequencePulseMock.Set(func(pulseNumber int) (err error) {
+	sm.SequencePulseMock.Set(func(pulseNumber int64) (err error) {
 		if sm.SequencePulseBeforeCounter() == 1 {
-			require.Equal(t, pulse.MinTimePulse, pulseNumber)
+			require.Equal(t, int64(pulse.MinTimePulse), pulseNumber)
 		}
 		return nil
 	})
@@ -141,43 +141,43 @@ func TestController_pulseSequence_StartFromSomething(t *testing.T) {
 			wg.Done()
 		}
 		if sm.GetPulseByPrevBeforeCounter() == 1 || sm.GetPulseByPrevBeforeCounter() == 2 {
-			require.Equal(t, 1000000, prevPulse.PulseNumber)
+			require.Equal(t, int64(1000000), prevPulse.PulseNumber)
 			return models.Pulse{}, nil
 		}
 		if sm.GetPulseByPrevBeforeCounter() == 3 {
-			require.Equal(t, 1000000, prevPulse.PulseNumber)
+			require.Equal(t, int64(1000000), prevPulse.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 1000000, PulseNumber: 1000010, NextPulseNumber: 1000020, IsComplete: true}, nil
 		}
 		if sm.GetPulseByPrevBeforeCounter() == 4 {
-			require.Equal(t, 1000010, prevPulse.PulseNumber)
+			require.Equal(t, int64(1000010), prevPulse.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 1000010, PulseNumber: 1000020, NextPulseNumber: 1000030, IsComplete: true}, nil
 		}
-		require.Equal(t, 1000020, prevPulse.PulseNumber)
+		require.Equal(t, int64(1000020), prevPulse.PulseNumber)
 		return models.Pulse{PrevPulseNumber: 1000020, PulseNumber: 1000030, NextPulseNumber: 1000040, IsComplete: false}, nil
 	})
 	sm.GetNextSavedPulseMock.Set(func(fromPulseNumber models.Pulse) (p1 models.Pulse, err error) {
 		if sm.GetNextSavedPulseBeforeCounter() == 1 || sm.GetPulseByPrevBeforeCounter() == 2 {
-			require.Equal(t, 1000000, fromPulseNumber.PulseNumber)
+			require.Equal(t, int64(1000000), fromPulseNumber.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 1000010, PulseNumber: 1000020, NextPulseNumber: 1000030}, nil
 		}
-		require.Equal(t, 1000020, fromPulseNumber.PulseNumber)
+		require.Equal(t, int64(1000020), fromPulseNumber.PulseNumber)
 		return models.Pulse{}, nil
 	})
-	extractor.LoadJetDropsMock.Set(func(ctx context.Context, fromPulseNumber int, toPulseNumber int) (err error) {
+	extractor.LoadJetDropsMock.Set(func(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) (err error) {
 		if extractor.LoadJetDropsBeforeCounter() == 1 {
-			require.Equal(t, 1000000, fromPulseNumber)
-			require.Equal(t, 1000020, toPulseNumber)
+			require.Equal(t, int64(1000000), fromPulseNumber)
+			require.Equal(t, int64(1000020), toPulseNumber)
 		} else {
 			require.Fail(t, "LoadJetDrops was called more than once")
 		}
 		return nil
 	})
-	sm.SequencePulseMock.Set(func(pulseNumber int) (err error) {
+	sm.SequencePulseMock.Set(func(pulseNumber int64) (err error) {
 		if sm.SequencePulseBeforeCounter() == 1 {
-			require.Equal(t, 1000010, pulseNumber)
+			require.Equal(t, int64(1000010), pulseNumber)
 		}
 		if sm.SequencePulseBeforeCounter() == 2 {
-			require.Equal(t, 1000020, pulseNumber)
+			require.Equal(t, int64(1000020), pulseNumber)
 		}
 		return nil
 	})
@@ -211,22 +211,22 @@ func TestController_pulseSequence_Start_NoMissedData(t *testing.T) {
 			wg.Done()
 		}
 		if sm.GetPulseByPrevBeforeCounter() == 1 {
-			require.Equal(t, 1000000, prevPulse.PulseNumber)
+			require.Equal(t, int64(1000000), prevPulse.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 1000000, PulseNumber: 1000010, NextPulseNumber: 1000020, IsComplete: true}, nil
 		}
 		if sm.GetPulseByPrevBeforeCounter() == 2 {
-			require.Equal(t, 1000010, prevPulse.PulseNumber)
+			require.Equal(t, int64(1000010), prevPulse.PulseNumber)
 			return models.Pulse{PrevPulseNumber: 1000010, PulseNumber: 1000020, NextPulseNumber: 1000030, IsComplete: true}, nil
 		}
-		require.Equal(t, 1000020, prevPulse.PulseNumber)
+		require.Equal(t, int64(1000020), prevPulse.PulseNumber)
 		return models.Pulse{PrevPulseNumber: 1000020, PulseNumber: 1000030, NextPulseNumber: 1000040, IsComplete: false}, nil
 	})
-	sm.SequencePulseMock.Set(func(pulseNumber int) (err error) {
+	sm.SequencePulseMock.Set(func(pulseNumber int64) (err error) {
 		if sm.SequencePulseBeforeCounter() == 1 {
-			require.Equal(t, 1000010, pulseNumber)
+			require.Equal(t, int64(1000010), pulseNumber)
 		}
 		if sm.SequencePulseBeforeCounter() == 2 {
-			require.Equal(t, 1000020, pulseNumber)
+			require.Equal(t, int64(1000020), pulseNumber)
 		}
 		return nil
 	})
@@ -262,15 +262,15 @@ func TestController_pulseMaintainer_Start_PulsesCompleteAndNot(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)
-	sm.CompletePulseMock.Set(func(pulseNumber int) (err error) {
-		require.Equal(t, 1000010, pulseNumber)
+	sm.CompletePulseMock.Set(func(pulseNumber int64) (err error) {
+		require.Equal(t, int64(1000010), pulseNumber)
 		require.EqualValues(t, 1, sm.CompletePulseBeforeCounter())
 		wg.Done()
 		return nil
 	})
-	extractor.LoadJetDropsMock.Set(func(ctx context.Context, fromPulseNumber int, toPulseNumber int) (err error) {
-		require.Equal(t, -1000000, fromPulseNumber)
-		require.Equal(t, -1000000, toPulseNumber)
+	extractor.LoadJetDropsMock.Set(func(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) (err error) {
+		require.Equal(t, int64(-1000000), fromPulseNumber)
+		require.Equal(t, int64(-1000000), toPulseNumber)
 		require.EqualValues(t, 1, extractor.LoadJetDropsBeforeCounter())
 		wg.Done()
 		return nil
@@ -307,9 +307,9 @@ func TestController_pulseSequence_ReloadPeriodExpired(t *testing.T) {
 	sm.GetNextSavedPulseMock.Set(func(fromPulseNumber models.Pulse) (p1 models.Pulse, err error) {
 		return models.Pulse{PrevPulseNumber: 1000010, PulseNumber: 1000020, NextPulseNumber: 1000030}, nil
 	})
-	extractor.LoadJetDropsMock.Set(func(ctx context.Context, fromPulseNumber int, toPulseNumber int) (err error) {
-		require.Equal(t, 1000000, fromPulseNumber)
-		require.Equal(t, 1000020, toPulseNumber)
+	extractor.LoadJetDropsMock.Set(func(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) (err error) {
+		require.Equal(t, int64(1000000), fromPulseNumber)
+		require.Equal(t, int64(1000020), toPulseNumber)
 		if extractor.LoadJetDropsBeforeCounter() > 2 {
 			require.Fail(t, "LoadJetDrops was called more than once")
 		}

--- a/etl/extractor/platform_impl.go
+++ b/etl/extractor/platform_impl.go
@@ -53,7 +53,7 @@ func (m *PlatformExtractor) GetJetDrops(ctx context.Context) <-chan *types.Platf
 	return m.mainJetDropsChan
 }
 
-func (m *PlatformExtractor) LoadJetDrops(ctx context.Context, fromPulseNumber int, toPulseNumber int) error {
+func (m *PlatformExtractor) LoadJetDrops(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) error {
 	if fromPulseNumber < 0 {
 		return errors.New("fromPulseNumber cannot be negative")
 	}
@@ -73,7 +73,7 @@ func (m *PlatformExtractor) LoadJetDrops(ctx context.Context, fromPulseNumber in
 	return nil
 }
 
-func (m *PlatformExtractor) getJetDrops(ctx context.Context, request *exporter.GetRecords, fromPulseNumber int, toPulseNumber int, shouldReload bool) {
+func (m *PlatformExtractor) getJetDrops(ctx context.Context, request *exporter.GetRecords, fromPulseNumber int64, toPulseNumber int64, shouldReload bool) {
 	unsignedToPulseNumber := uint32(toPulseNumber)
 
 	client := m.client

--- a/etl/extractor/platform_test.go
+++ b/etl/extractor/platform_test.go
@@ -116,7 +116,7 @@ func TestLoadJetDrops_returnsRecordByPulses(t *testing.T) {
 			pulseClient := clients.GetTestPulseClient(1, nil)
 			pulseExtractor := NewPlatformPulseExtractor(pulseClient)
 			extractor := NewPlatformExtractor(uint32(test.recordCount), pulseExtractor, recordClient)
-			err = extractor.LoadJetDrops(ctx, startPulseNumber, startPulseNumber+10*test.differentPulseCount)
+			err = extractor.LoadJetDrops(ctx, int64(startPulseNumber), int64(startPulseNumber+10*test.differentPulseCount))
 			require.NoError(t, err)
 			// we are waiting only 2 times, because of 2 different pulses
 			for i := 0; i < test.differentPulseCount; {

--- a/etl/interfaces/interfaces.go
+++ b/etl/interfaces/interfaces.go
@@ -34,7 +34,7 @@ type JetDropsExtractor interface {
 	// GetJetDrops stores JetDrop data in the main JetDrop channel
 	GetJetDrops(ctx context.Context) <-chan *types.PlatformJetDrops
 	// LoadJetDrops loads JetDrop data between pulse numbers
-	LoadJetDrops(ctx context.Context, fromPulseNumber int, toPulseNumber int) error
+	LoadJetDrops(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) error
 }
 
 //go:generate minimock -i github.com/insolar/block-explorer/etl/interfaces.PulseExtractor -o ./mock -s _mock.go -g
@@ -90,9 +90,9 @@ type StorageSetter interface {
 	// SavePulse saves provided pulse to db.
 	SavePulse(pulse models.Pulse) error
 	// CompletePulse update pulse with provided number to completeness in db.
-	CompletePulse(pulseNumber int) error
+	CompletePulse(pulseNumber int64) error
 	// SequencePulse update pulse with provided number to sequential in db.
-	SequencePulse(pulseNumber int) error
+	SequencePulse(pulseNumber int64) error
 }
 
 // StorageAPIFetcher gets data from database
@@ -100,19 +100,19 @@ type StorageAPIFetcher interface {
 	// GetRecord returns record with provided reference from db.
 	GetRecord(ref models.Reference) (models.Record, error)
 	// GetPulse returns pulse with provided pulse number from db.
-	GetPulse(pulseNumber int) (models.Pulse, int64, int64, error)
+	GetPulse(pulseNumber int64) (models.Pulse, int64, int64, error)
 	// GetAmounts return amount of jetDrops and records at provided pulse.
-	GetAmounts(pulseNumber int) (jdAmount int64, rAmount int64, err error)
+	GetAmounts(pulseNumber int64) (jdAmount int64, rAmount int64, err error)
 	// GetPulse returns pulses from db.
-	GetPulses(fromPulse *int64, timestampLte, timestampGte *int, limit, offset int) ([]models.Pulse, int, error)
+	GetPulses(fromPulse *int64, timestampLte, timestampGte *int64, limit, offset int) ([]models.Pulse, int, error)
 	// GetJetDropsWithParams returns jetDrops for provided pulse with limit and offset.
 	GetJetDropsWithParams(pulse models.Pulse, fromJetDropID *models.JetDropID, limit int, offset int) ([]models.JetDrop, int, error)
 	// GetJetDropByID returns JetDrop by JetDropID
 	GetJetDropByID(id models.JetDropID) (models.JetDrop, error)
 	// GetJetDropsByJetID returns jetDrops for provided jetID sorting and filtering by pulseNumber.
-	GetJetDropsByJetID(jetID string, pulseNumberLte, pulseNumberLt, pulseNumberGte, pulseNumberGt *int, limit int, sortByPnAsc bool) ([]models.JetDrop, int, error)
+	GetJetDropsByJetID(jetID string, pulseNumberLte, pulseNumberLt, pulseNumberGte, pulseNumberGt *int64, limit int, sortByPnAsc bool) ([]models.JetDrop, int, error)
 	// GetLifeline returns records for provided object reference, ordered by desc by pulse number and order fields.
-	GetLifeline(objRef []byte, fromIndex *string, pulseNumberLt, pulseNumberGt, timestampLte, timestampGte *int, limit, offset int, sortByIndexAsc bool) ([]models.Record, int, error)
+	GetLifeline(objRef []byte, fromIndex *string, pulseNumberLt, pulseNumberGt, timestampLte, timestampGte *int64, limit, offset int, sortByIndexAsc bool) ([]models.Record, int, error)
 	// GetRecordsByJetDrop returns records for provided jet drop, ordered by order field.
 	GetRecordsByJetDrop(jetDropID models.JetDropID, fromIndex, recordType *string, limit, offset int) ([]models.Record, int, error)
 }

--- a/etl/interfaces/mock/jet_drops_extractor_mock.go
+++ b/etl/interfaces/mock/jet_drops_extractor_mock.go
@@ -22,8 +22,8 @@ type JetDropsExtractorMock struct {
 	beforeGetJetDropsCounter uint64
 	GetJetDropsMock          mJetDropsExtractorMockGetJetDrops
 
-	funcLoadJetDrops          func(ctx context.Context, fromPulseNumber int, toPulseNumber int) (err error)
-	inspectFuncLoadJetDrops   func(ctx context.Context, fromPulseNumber int, toPulseNumber int)
+	funcLoadJetDrops          func(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) (err error)
+	inspectFuncLoadJetDrops   func(ctx context.Context, fromPulseNumber int64, toPulseNumber int64)
 	afterLoadJetDropsCounter  uint64
 	beforeLoadJetDropsCounter uint64
 	LoadJetDropsMock          mJetDropsExtractorMockLoadJetDrops
@@ -298,8 +298,8 @@ type JetDropsExtractorMockLoadJetDropsExpectation struct {
 // JetDropsExtractorMockLoadJetDropsParams contains parameters of the JetDropsExtractor.LoadJetDrops
 type JetDropsExtractorMockLoadJetDropsParams struct {
 	ctx             context.Context
-	fromPulseNumber int
-	toPulseNumber   int
+	fromPulseNumber int64
+	toPulseNumber   int64
 }
 
 // JetDropsExtractorMockLoadJetDropsResults contains results of the JetDropsExtractor.LoadJetDrops
@@ -308,7 +308,7 @@ type JetDropsExtractorMockLoadJetDropsResults struct {
 }
 
 // Expect sets up expected params for JetDropsExtractor.LoadJetDrops
-func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Expect(ctx context.Context, fromPulseNumber int, toPulseNumber int) *mJetDropsExtractorMockLoadJetDrops {
+func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Expect(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) *mJetDropsExtractorMockLoadJetDrops {
 	if mmLoadJetDrops.mock.funcLoadJetDrops != nil {
 		mmLoadJetDrops.mock.t.Fatalf("JetDropsExtractorMock.LoadJetDrops mock is already set by Set")
 	}
@@ -328,7 +328,7 @@ func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Expect(ctx context.Con
 }
 
 // Inspect accepts an inspector function that has same arguments as the JetDropsExtractor.LoadJetDrops
-func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Inspect(f func(ctx context.Context, fromPulseNumber int, toPulseNumber int)) *mJetDropsExtractorMockLoadJetDrops {
+func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Inspect(f func(ctx context.Context, fromPulseNumber int64, toPulseNumber int64)) *mJetDropsExtractorMockLoadJetDrops {
 	if mmLoadJetDrops.mock.inspectFuncLoadJetDrops != nil {
 		mmLoadJetDrops.mock.t.Fatalf("Inspect function is already set for JetDropsExtractorMock.LoadJetDrops")
 	}
@@ -352,7 +352,7 @@ func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Return(err error) *Jet
 }
 
 //Set uses given function f to mock the JetDropsExtractor.LoadJetDrops method
-func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Set(f func(ctx context.Context, fromPulseNumber int, toPulseNumber int) (err error)) *JetDropsExtractorMock {
+func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Set(f func(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) (err error)) *JetDropsExtractorMock {
 	if mmLoadJetDrops.defaultExpectation != nil {
 		mmLoadJetDrops.mock.t.Fatalf("Default expectation is already set for the JetDropsExtractor.LoadJetDrops method")
 	}
@@ -367,7 +367,7 @@ func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) Set(f func(ctx context
 
 // When sets expectation for the JetDropsExtractor.LoadJetDrops which will trigger the result defined by the following
 // Then helper
-func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) When(ctx context.Context, fromPulseNumber int, toPulseNumber int) *JetDropsExtractorMockLoadJetDropsExpectation {
+func (mmLoadJetDrops *mJetDropsExtractorMockLoadJetDrops) When(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) *JetDropsExtractorMockLoadJetDropsExpectation {
 	if mmLoadJetDrops.mock.funcLoadJetDrops != nil {
 		mmLoadJetDrops.mock.t.Fatalf("JetDropsExtractorMock.LoadJetDrops mock is already set by Set")
 	}
@@ -387,7 +387,7 @@ func (e *JetDropsExtractorMockLoadJetDropsExpectation) Then(err error) *JetDrops
 }
 
 // LoadJetDrops implements interfaces.JetDropsExtractor
-func (mmLoadJetDrops *JetDropsExtractorMock) LoadJetDrops(ctx context.Context, fromPulseNumber int, toPulseNumber int) (err error) {
+func (mmLoadJetDrops *JetDropsExtractorMock) LoadJetDrops(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) (err error) {
 	mm_atomic.AddUint64(&mmLoadJetDrops.beforeLoadJetDropsCounter, 1)
 	defer mm_atomic.AddUint64(&mmLoadJetDrops.afterLoadJetDropsCounter, 1)
 

--- a/etl/interfaces/mock/storage_mock.go
+++ b/etl/interfaces/mock/storage_mock.go
@@ -15,8 +15,8 @@ import (
 type StorageMock struct {
 	t minimock.Tester
 
-	funcCompletePulse          func(pulseNumber int) (err error)
-	inspectFuncCompletePulse   func(pulseNumber int)
+	funcCompletePulse          func(pulseNumber int64) (err error)
+	inspectFuncCompletePulse   func(pulseNumber int64)
 	afterCompletePulseCounter  uint64
 	beforeCompletePulseCounter uint64
 	CompletePulseMock          mStorageMockCompletePulse
@@ -63,8 +63,8 @@ type StorageMock struct {
 	beforeSavePulseCounter uint64
 	SavePulseMock          mStorageMockSavePulse
 
-	funcSequencePulse          func(pulseNumber int) (err error)
-	inspectFuncSequencePulse   func(pulseNumber int)
+	funcSequencePulse          func(pulseNumber int64) (err error)
+	inspectFuncSequencePulse   func(pulseNumber int64)
 	afterSequencePulseCounter  uint64
 	beforeSequencePulseCounter uint64
 	SequencePulseMock          mStorageMockSequencePulse
@@ -124,7 +124,7 @@ type StorageMockCompletePulseExpectation struct {
 
 // StorageMockCompletePulseParams contains parameters of the Storage.CompletePulse
 type StorageMockCompletePulseParams struct {
-	pulseNumber int
+	pulseNumber int64
 }
 
 // StorageMockCompletePulseResults contains results of the Storage.CompletePulse
@@ -133,7 +133,7 @@ type StorageMockCompletePulseResults struct {
 }
 
 // Expect sets up expected params for Storage.CompletePulse
-func (mmCompletePulse *mStorageMockCompletePulse) Expect(pulseNumber int) *mStorageMockCompletePulse {
+func (mmCompletePulse *mStorageMockCompletePulse) Expect(pulseNumber int64) *mStorageMockCompletePulse {
 	if mmCompletePulse.mock.funcCompletePulse != nil {
 		mmCompletePulse.mock.t.Fatalf("StorageMock.CompletePulse mock is already set by Set")
 	}
@@ -153,7 +153,7 @@ func (mmCompletePulse *mStorageMockCompletePulse) Expect(pulseNumber int) *mStor
 }
 
 // Inspect accepts an inspector function that has same arguments as the Storage.CompletePulse
-func (mmCompletePulse *mStorageMockCompletePulse) Inspect(f func(pulseNumber int)) *mStorageMockCompletePulse {
+func (mmCompletePulse *mStorageMockCompletePulse) Inspect(f func(pulseNumber int64)) *mStorageMockCompletePulse {
 	if mmCompletePulse.mock.inspectFuncCompletePulse != nil {
 		mmCompletePulse.mock.t.Fatalf("Inspect function is already set for StorageMock.CompletePulse")
 	}
@@ -177,7 +177,7 @@ func (mmCompletePulse *mStorageMockCompletePulse) Return(err error) *StorageMock
 }
 
 //Set uses given function f to mock the Storage.CompletePulse method
-func (mmCompletePulse *mStorageMockCompletePulse) Set(f func(pulseNumber int) (err error)) *StorageMock {
+func (mmCompletePulse *mStorageMockCompletePulse) Set(f func(pulseNumber int64) (err error)) *StorageMock {
 	if mmCompletePulse.defaultExpectation != nil {
 		mmCompletePulse.mock.t.Fatalf("Default expectation is already set for the Storage.CompletePulse method")
 	}
@@ -192,7 +192,7 @@ func (mmCompletePulse *mStorageMockCompletePulse) Set(f func(pulseNumber int) (e
 
 // When sets expectation for the Storage.CompletePulse which will trigger the result defined by the following
 // Then helper
-func (mmCompletePulse *mStorageMockCompletePulse) When(pulseNumber int) *StorageMockCompletePulseExpectation {
+func (mmCompletePulse *mStorageMockCompletePulse) When(pulseNumber int64) *StorageMockCompletePulseExpectation {
 	if mmCompletePulse.mock.funcCompletePulse != nil {
 		mmCompletePulse.mock.t.Fatalf("StorageMock.CompletePulse mock is already set by Set")
 	}
@@ -212,7 +212,7 @@ func (e *StorageMockCompletePulseExpectation) Then(err error) *StorageMock {
 }
 
 // CompletePulse implements interfaces.Storage
-func (mmCompletePulse *StorageMock) CompletePulse(pulseNumber int) (err error) {
+func (mmCompletePulse *StorageMock) CompletePulse(pulseNumber int64) (err error) {
 	mm_atomic.AddUint64(&mmCompletePulse.beforeCompletePulseCounter, 1)
 	defer mm_atomic.AddUint64(&mmCompletePulse.afterCompletePulseCounter, 1)
 
@@ -1706,7 +1706,7 @@ type StorageMockSequencePulseExpectation struct {
 
 // StorageMockSequencePulseParams contains parameters of the Storage.SequencePulse
 type StorageMockSequencePulseParams struct {
-	pulseNumber int
+	pulseNumber int64
 }
 
 // StorageMockSequencePulseResults contains results of the Storage.SequencePulse
@@ -1715,7 +1715,7 @@ type StorageMockSequencePulseResults struct {
 }
 
 // Expect sets up expected params for Storage.SequencePulse
-func (mmSequencePulse *mStorageMockSequencePulse) Expect(pulseNumber int) *mStorageMockSequencePulse {
+func (mmSequencePulse *mStorageMockSequencePulse) Expect(pulseNumber int64) *mStorageMockSequencePulse {
 	if mmSequencePulse.mock.funcSequencePulse != nil {
 		mmSequencePulse.mock.t.Fatalf("StorageMock.SequencePulse mock is already set by Set")
 	}
@@ -1735,7 +1735,7 @@ func (mmSequencePulse *mStorageMockSequencePulse) Expect(pulseNumber int) *mStor
 }
 
 // Inspect accepts an inspector function that has same arguments as the Storage.SequencePulse
-func (mmSequencePulse *mStorageMockSequencePulse) Inspect(f func(pulseNumber int)) *mStorageMockSequencePulse {
+func (mmSequencePulse *mStorageMockSequencePulse) Inspect(f func(pulseNumber int64)) *mStorageMockSequencePulse {
 	if mmSequencePulse.mock.inspectFuncSequencePulse != nil {
 		mmSequencePulse.mock.t.Fatalf("Inspect function is already set for StorageMock.SequencePulse")
 	}
@@ -1759,7 +1759,7 @@ func (mmSequencePulse *mStorageMockSequencePulse) Return(err error) *StorageMock
 }
 
 //Set uses given function f to mock the Storage.SequencePulse method
-func (mmSequencePulse *mStorageMockSequencePulse) Set(f func(pulseNumber int) (err error)) *StorageMock {
+func (mmSequencePulse *mStorageMockSequencePulse) Set(f func(pulseNumber int64) (err error)) *StorageMock {
 	if mmSequencePulse.defaultExpectation != nil {
 		mmSequencePulse.mock.t.Fatalf("Default expectation is already set for the Storage.SequencePulse method")
 	}
@@ -1774,7 +1774,7 @@ func (mmSequencePulse *mStorageMockSequencePulse) Set(f func(pulseNumber int) (e
 
 // When sets expectation for the Storage.SequencePulse which will trigger the result defined by the following
 // Then helper
-func (mmSequencePulse *mStorageMockSequencePulse) When(pulseNumber int) *StorageMockSequencePulseExpectation {
+func (mmSequencePulse *mStorageMockSequencePulse) When(pulseNumber int64) *StorageMockSequencePulseExpectation {
 	if mmSequencePulse.mock.funcSequencePulse != nil {
 		mmSequencePulse.mock.t.Fatalf("StorageMock.SequencePulse mock is already set by Set")
 	}
@@ -1794,7 +1794,7 @@ func (e *StorageMockSequencePulseExpectation) Then(err error) *StorageMock {
 }
 
 // SequencePulse implements interfaces.Storage
-func (mmSequencePulse *StorageMock) SequencePulse(pulseNumber int) (err error) {
+func (mmSequencePulse *StorageMock) SequencePulse(pulseNumber int64) (err error) {
 	mm_atomic.AddUint64(&mmSequencePulse.beforeSequencePulseCounter, 1)
 	defer mm_atomic.AddUint64(&mmSequencePulse.afterSequencePulseCounter, 1)
 

--- a/etl/interfaces/mock/storage_setter_mock.go
+++ b/etl/interfaces/mock/storage_setter_mock.go
@@ -15,8 +15,8 @@ import (
 type StorageSetterMock struct {
 	t minimock.Tester
 
-	funcCompletePulse          func(pulseNumber int) (err error)
-	inspectFuncCompletePulse   func(pulseNumber int)
+	funcCompletePulse          func(pulseNumber int64) (err error)
+	inspectFuncCompletePulse   func(pulseNumber int64)
 	afterCompletePulseCounter  uint64
 	beforeCompletePulseCounter uint64
 	CompletePulseMock          mStorageSetterMockCompletePulse
@@ -33,8 +33,8 @@ type StorageSetterMock struct {
 	beforeSavePulseCounter uint64
 	SavePulseMock          mStorageSetterMockSavePulse
 
-	funcSequencePulse          func(pulseNumber int) (err error)
-	inspectFuncSequencePulse   func(pulseNumber int)
+	funcSequencePulse          func(pulseNumber int64) (err error)
+	inspectFuncSequencePulse   func(pulseNumber int64)
 	afterSequencePulseCounter  uint64
 	beforeSequencePulseCounter uint64
 	SequencePulseMock          mStorageSetterMockSequencePulse
@@ -81,7 +81,7 @@ type StorageSetterMockCompletePulseExpectation struct {
 
 // StorageSetterMockCompletePulseParams contains parameters of the StorageSetter.CompletePulse
 type StorageSetterMockCompletePulseParams struct {
-	pulseNumber int
+	pulseNumber int64
 }
 
 // StorageSetterMockCompletePulseResults contains results of the StorageSetter.CompletePulse
@@ -90,7 +90,7 @@ type StorageSetterMockCompletePulseResults struct {
 }
 
 // Expect sets up expected params for StorageSetter.CompletePulse
-func (mmCompletePulse *mStorageSetterMockCompletePulse) Expect(pulseNumber int) *mStorageSetterMockCompletePulse {
+func (mmCompletePulse *mStorageSetterMockCompletePulse) Expect(pulseNumber int64) *mStorageSetterMockCompletePulse {
 	if mmCompletePulse.mock.funcCompletePulse != nil {
 		mmCompletePulse.mock.t.Fatalf("StorageSetterMock.CompletePulse mock is already set by Set")
 	}
@@ -110,7 +110,7 @@ func (mmCompletePulse *mStorageSetterMockCompletePulse) Expect(pulseNumber int) 
 }
 
 // Inspect accepts an inspector function that has same arguments as the StorageSetter.CompletePulse
-func (mmCompletePulse *mStorageSetterMockCompletePulse) Inspect(f func(pulseNumber int)) *mStorageSetterMockCompletePulse {
+func (mmCompletePulse *mStorageSetterMockCompletePulse) Inspect(f func(pulseNumber int64)) *mStorageSetterMockCompletePulse {
 	if mmCompletePulse.mock.inspectFuncCompletePulse != nil {
 		mmCompletePulse.mock.t.Fatalf("Inspect function is already set for StorageSetterMock.CompletePulse")
 	}
@@ -134,7 +134,7 @@ func (mmCompletePulse *mStorageSetterMockCompletePulse) Return(err error) *Stora
 }
 
 //Set uses given function f to mock the StorageSetter.CompletePulse method
-func (mmCompletePulse *mStorageSetterMockCompletePulse) Set(f func(pulseNumber int) (err error)) *StorageSetterMock {
+func (mmCompletePulse *mStorageSetterMockCompletePulse) Set(f func(pulseNumber int64) (err error)) *StorageSetterMock {
 	if mmCompletePulse.defaultExpectation != nil {
 		mmCompletePulse.mock.t.Fatalf("Default expectation is already set for the StorageSetter.CompletePulse method")
 	}
@@ -149,7 +149,7 @@ func (mmCompletePulse *mStorageSetterMockCompletePulse) Set(f func(pulseNumber i
 
 // When sets expectation for the StorageSetter.CompletePulse which will trigger the result defined by the following
 // Then helper
-func (mmCompletePulse *mStorageSetterMockCompletePulse) When(pulseNumber int) *StorageSetterMockCompletePulseExpectation {
+func (mmCompletePulse *mStorageSetterMockCompletePulse) When(pulseNumber int64) *StorageSetterMockCompletePulseExpectation {
 	if mmCompletePulse.mock.funcCompletePulse != nil {
 		mmCompletePulse.mock.t.Fatalf("StorageSetterMock.CompletePulse mock is already set by Set")
 	}
@@ -169,7 +169,7 @@ func (e *StorageSetterMockCompletePulseExpectation) Then(err error) *StorageSett
 }
 
 // CompletePulse implements interfaces.StorageSetter
-func (mmCompletePulse *StorageSetterMock) CompletePulse(pulseNumber int) (err error) {
+func (mmCompletePulse *StorageSetterMock) CompletePulse(pulseNumber int64) (err error) {
 	mm_atomic.AddUint64(&mmCompletePulse.beforeCompletePulseCounter, 1)
 	defer mm_atomic.AddUint64(&mmCompletePulse.afterCompletePulseCounter, 1)
 
@@ -727,7 +727,7 @@ type StorageSetterMockSequencePulseExpectation struct {
 
 // StorageSetterMockSequencePulseParams contains parameters of the StorageSetter.SequencePulse
 type StorageSetterMockSequencePulseParams struct {
-	pulseNumber int
+	pulseNumber int64
 }
 
 // StorageSetterMockSequencePulseResults contains results of the StorageSetter.SequencePulse
@@ -736,7 +736,7 @@ type StorageSetterMockSequencePulseResults struct {
 }
 
 // Expect sets up expected params for StorageSetter.SequencePulse
-func (mmSequencePulse *mStorageSetterMockSequencePulse) Expect(pulseNumber int) *mStorageSetterMockSequencePulse {
+func (mmSequencePulse *mStorageSetterMockSequencePulse) Expect(pulseNumber int64) *mStorageSetterMockSequencePulse {
 	if mmSequencePulse.mock.funcSequencePulse != nil {
 		mmSequencePulse.mock.t.Fatalf("StorageSetterMock.SequencePulse mock is already set by Set")
 	}
@@ -756,7 +756,7 @@ func (mmSequencePulse *mStorageSetterMockSequencePulse) Expect(pulseNumber int) 
 }
 
 // Inspect accepts an inspector function that has same arguments as the StorageSetter.SequencePulse
-func (mmSequencePulse *mStorageSetterMockSequencePulse) Inspect(f func(pulseNumber int)) *mStorageSetterMockSequencePulse {
+func (mmSequencePulse *mStorageSetterMockSequencePulse) Inspect(f func(pulseNumber int64)) *mStorageSetterMockSequencePulse {
 	if mmSequencePulse.mock.inspectFuncSequencePulse != nil {
 		mmSequencePulse.mock.t.Fatalf("Inspect function is already set for StorageSetterMock.SequencePulse")
 	}
@@ -780,7 +780,7 @@ func (mmSequencePulse *mStorageSetterMockSequencePulse) Return(err error) *Stora
 }
 
 //Set uses given function f to mock the StorageSetter.SequencePulse method
-func (mmSequencePulse *mStorageSetterMockSequencePulse) Set(f func(pulseNumber int) (err error)) *StorageSetterMock {
+func (mmSequencePulse *mStorageSetterMockSequencePulse) Set(f func(pulseNumber int64) (err error)) *StorageSetterMock {
 	if mmSequencePulse.defaultExpectation != nil {
 		mmSequencePulse.mock.t.Fatalf("Default expectation is already set for the StorageSetter.SequencePulse method")
 	}
@@ -795,7 +795,7 @@ func (mmSequencePulse *mStorageSetterMockSequencePulse) Set(f func(pulseNumber i
 
 // When sets expectation for the StorageSetter.SequencePulse which will trigger the result defined by the following
 // Then helper
-func (mmSequencePulse *mStorageSetterMockSequencePulse) When(pulseNumber int) *StorageSetterMockSequencePulseExpectation {
+func (mmSequencePulse *mStorageSetterMockSequencePulse) When(pulseNumber int64) *StorageSetterMockSequencePulseExpectation {
 	if mmSequencePulse.mock.funcSequencePulse != nil {
 		mmSequencePulse.mock.t.Fatalf("StorageSetterMock.SequencePulse mock is already set by Set")
 	}
@@ -815,7 +815,7 @@ func (e *StorageSetterMockSequencePulseExpectation) Then(err error) *StorageSett
 }
 
 // SequencePulse implements interfaces.StorageSetter
-func (mmSequencePulse *StorageSetterMock) SequencePulse(pulseNumber int) (err error) {
+func (mmSequencePulse *StorageSetterMock) SequencePulse(pulseNumber int64) (err error) {
 	mm_atomic.AddUint64(&mmSequencePulse.beforeSequencePulseCounter, 1)
 	defer mm_atomic.AddUint64(&mmSequencePulse.afterSequencePulseCounter, 1)
 

--- a/etl/models/models.go
+++ b/etl/models/models.go
@@ -49,7 +49,7 @@ type Record struct {
 }
 
 type JetDrop struct {
-	PulseNumber    int64    `gorm:"primary_key;auto_increment:false"`
+	PulseNumber    int64  `gorm:"primary_key;auto_increment:false"`
 	JetID          string `gorm:"primary_key;auto_increment:false;default:''"`
 	FirstPrevHash  []byte
 	SecondPrevHash []byte

--- a/etl/models/models.go
+++ b/etl/models/models.go
@@ -43,14 +43,14 @@ type Record struct {
 	Hash                []byte
 	RawData             []byte
 	JetID               string
-	PulseNumber         int
+	PulseNumber         int64
 	Order               int
 	Timestamp           int64
 }
 
 type JetDrop struct {
 	JetID          string `gorm:"primary_key;auto_increment:false;default:''"`
-	PulseNumber    int    `gorm:"primary_key;auto_increment:false"`
+	PulseNumber    int64  `gorm:"primary_key;auto_increment:false"`
 	FirstPrevHash  []byte
 	SecondPrevHash []byte
 	Hash           []byte
@@ -60,9 +60,9 @@ type JetDrop struct {
 }
 
 type Pulse struct {
-	PulseNumber     int `gorm:"primary_key;auto_increment:false"`
-	PrevPulseNumber int
-	NextPulseNumber int
+	PulseNumber     int64 `gorm:"primary_key;auto_increment:false"`
+	PrevPulseNumber int64
+	NextPulseNumber int64
 	IsComplete      bool
 	IsSequential    bool
 	Timestamp       int64

--- a/etl/processor/processor.go
+++ b/etl/processor/processor.go
@@ -120,8 +120,8 @@ func (p *Processor) process(ctx context.Context, jd *types.JetDrop) {
 	}
 	mp := models.Pulse{
 		PulseNumber:     pd.PulseNo,
-		PrevPulseNumber: int(prevPN),
-		NextPulseNumber: int(nextPN),
+		PrevPulseNumber: int64(prevPN),
+		NextPulseNumber: int64(nextPN),
 		IsComplete:      false,
 		Timestamp:       pd.PulseTimestamp,
 	}

--- a/etl/processor/processor_test.go
+++ b/etl/processor/processor_test.go
@@ -68,7 +68,7 @@ func TestNewProcessor(t *testing.T) {
 			MainSection: &types.MainSection{
 				Start: types.DropStart{
 					PulseData: types.Pulse{
-						PulseNo:        int(gen.PulseNumber()),
+						PulseNo:        int64(gen.PulseNumber()),
 						NextPulseDelta: 10,
 						PrevPulseDelta: 10,
 					},
@@ -104,8 +104,8 @@ func TestProcessor_process_EmptyPrev(t *testing.T) {
 	sm := mock.NewStorageSetterMock(t)
 	sm.SavePulseMock.Set(func(pulse models.Pulse) (err error) {
 		require.Equal(t, jd.MainSection.Start.PulseData.PulseNo, pulse.PulseNumber)
-		require.Equal(t, jd.MainSection.Start.PulseData.PrevPulseDelta, pulse.PulseNumber-pulse.PrevPulseNumber)
-		require.Equal(t, jd.MainSection.Start.PulseData.NextPulseDelta, pulse.NextPulseNumber-pulse.PulseNumber)
+		require.Equal(t, int64(jd.MainSection.Start.PulseData.PrevPulseDelta), pulse.PulseNumber-pulse.PrevPulseNumber)
+		require.Equal(t, int64(jd.MainSection.Start.PulseData.NextPulseDelta), pulse.NextPulseNumber-pulse.PulseNumber)
 		return nil
 	})
 	sm.SaveJetDropDataMock.Set(func(jetDrop models.JetDrop, records []models.Record) (err error) {
@@ -144,8 +144,8 @@ func TestProcessor_process_SeveralPrev(t *testing.T) {
 	sm := mock.NewStorageSetterMock(t)
 	sm.SavePulseMock.Set(func(pulse models.Pulse) (err error) {
 		require.Equal(t, jd.MainSection.Start.PulseData.PulseNo, pulse.PulseNumber)
-		require.Equal(t, jd.MainSection.Start.PulseData.PrevPulseDelta, pulse.PulseNumber-pulse.PrevPulseNumber)
-		require.Equal(t, jd.MainSection.Start.PulseData.NextPulseDelta, pulse.NextPulseNumber-pulse.PulseNumber)
+		require.Equal(t, int64(jd.MainSection.Start.PulseData.PrevPulseDelta), pulse.PulseNumber-pulse.PrevPulseNumber)
+		require.Equal(t, int64(jd.MainSection.Start.PulseData.NextPulseDelta), pulse.NextPulseNumber-pulse.PulseNumber)
 		return nil
 	})
 	sm.SaveJetDropDataMock.Set(func(jetDrop models.JetDrop, records []models.Record) (err error) {

--- a/etl/storage/storage.go
+++ b/etl/storage/storage.go
@@ -50,7 +50,7 @@ func (s *Storage) SavePulse(pulse models.Pulse) error {
 }
 
 // CompletePulse update pulse with provided number to completeness in db.
-func (s *Storage) CompletePulse(pulseNumber int) error {
+func (s *Storage) CompletePulse(pulseNumber int64) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		pulse := models.Pulse{PulseNumber: pulseNumber}
 		update := tx.Model(&pulse).Update(models.Pulse{IsComplete: true})
@@ -69,7 +69,7 @@ func (s *Storage) CompletePulse(pulseNumber int) error {
 }
 
 // SequencePulse update pulse with provided number to sequential in db.
-func (s *Storage) SequencePulse(pulseNumber int) error {
+func (s *Storage) SequencePulse(pulseNumber int64) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		pulse := models.Pulse{PulseNumber: pulseNumber}
 		update := tx.Model(&pulse).Update(models.Pulse{IsSequential: true})
@@ -112,7 +112,7 @@ func CheckIndex(i string) (int, int, error) {
 	return int(pulseNumber), int(order), nil
 }
 
-func filterByPulse(query *gorm.DB, pulseNumberLt, pulseNumberGt *int) *gorm.DB {
+func filterByPulse(query *gorm.DB, pulseNumberLt, pulseNumberGt *int64) *gorm.DB {
 	if pulseNumberGt != nil {
 		query = query.Where("pulse_number > ?", *pulseNumberGt)
 	}
@@ -122,7 +122,7 @@ func filterByPulse(query *gorm.DB, pulseNumberLt, pulseNumberGt *int) *gorm.DB {
 	return query
 }
 
-func filterByPulseNumber(query *gorm.DB, pulseNumberLte, pulseNumberLt, pulseNumberGte, pulseNumberGt *int) *gorm.DB {
+func filterByPulseNumber(query *gorm.DB, pulseNumberLte, pulseNumberLt, pulseNumberGte, pulseNumberGt *int64) *gorm.DB {
 	if pulseNumberLte != nil {
 		query = query.Where("pulse_number <= ?", *pulseNumberLte)
 	}
@@ -157,7 +157,7 @@ func filterRecordsByIndex(query *gorm.DB, fromIndex string, sortByIndexAsc bool)
 	return query, nil
 }
 
-func filterByTimestamp(query *gorm.DB, timestampLte, timestampGte *int) *gorm.DB {
+func filterByTimestamp(query *gorm.DB, timestampLte, timestampGte *int64) *gorm.DB {
 	if timestampGte != nil {
 		query = query.Where("timestamp >= ?", *timestampGte)
 	}
@@ -205,7 +205,7 @@ func getPulses(query *gorm.DB, limit, offset int) ([]models.Pulse, int, error) {
 }
 
 // GetLifeline returns records for provided object reference, ordered by pulse number and order fields.
-func (s *Storage) GetLifeline(objRef []byte, fromIndex *string, pulseNumberLt, pulseNumberGt, timestampLte, timestampGte *int, limit, offset int, sortByIndexAsc bool) ([]models.Record, int, error) {
+func (s *Storage) GetLifeline(objRef []byte, fromIndex *string, pulseNumberLt, pulseNumberGt, timestampLte, timestampGte *int64, limit, offset int, sortByIndexAsc bool) ([]models.Record, int, error) {
 	query := s.db.Model(&models.Record{}).Where("object_reference = ?", objRef).Where("type = ?", models.State)
 
 	query = filterByPulse(query, pulseNumberLt, pulseNumberGt)
@@ -230,7 +230,7 @@ func (s *Storage) GetLifeline(objRef []byte, fromIndex *string, pulseNumberLt, p
 }
 
 // GetPulse returns pulse with provided pulse number from db.
-func (s *Storage) GetPulse(pulseNumber int) (models.Pulse, int64, int64, error) {
+func (s *Storage) GetPulse(pulseNumber int64) (models.Pulse, int64, int64, error) {
 	var pulse models.Pulse
 	err := s.db.Where("pulse_number = ?", pulseNumber).First(&pulse).Error
 	if err != nil {
@@ -248,7 +248,7 @@ func (s *Storage) GetPulse(pulseNumber int) (models.Pulse, int64, int64, error) 
 }
 
 // GetAmounts return amount of jetDrops and records at provided pulse.
-func (s *Storage) GetAmounts(pulseNumber int) (int64, int64, error) {
+func (s *Storage) GetAmounts(pulseNumber int64) (int64, int64, error) {
 	res := struct {
 		JetDrops int
 		Records  int
@@ -262,7 +262,7 @@ func (s *Storage) GetAmounts(pulseNumber int) (int64, int64, error) {
 }
 
 // GetPulses returns pulses from db.
-func (s *Storage) GetPulses(fromPulse *int64, timestampLte, timestampGte *int, limit, offset int) ([]models.Pulse, int, error) {
+func (s *Storage) GetPulses(fromPulse *int64, timestampLte, timestampGte *int64, limit, offset int) ([]models.Pulse, int, error) {
 	query := s.db.Model(&models.Pulse{})
 
 	query = filterByTimestamp(query, timestampLte, timestampGte)
@@ -398,7 +398,7 @@ func (s *Storage) GetJetDropByID(id models.JetDropID) (models.JetDrop, error) {
 	return jetDrop, err
 }
 
-func (s *Storage) GetJetDropsByJetID(jetID string, pulseNumberLte, pulseNumberLt, pulseNumberGte, pulseNumberGt *int, limit int, sortByPnAsc bool) ([]models.JetDrop, int, error) {
+func (s *Storage) GetJetDropsByJetID(jetID string, pulseNumberLte, pulseNumberLt, pulseNumberGte, pulseNumberGt *int64, limit int, sortByPnAsc bool) ([]models.JetDrop, int, error) {
 	var jetDrops []models.JetDrop
 	var total int64
 

--- a/etl/storage/storage_test.go
+++ b/etl/storage/storage_test.go
@@ -534,7 +534,7 @@ func pulseSequenceOneObject(t *testing.T, pulseAmount, recordsAmount int) []puls
 	for i := 0; i < pulseAmount; i++ {
 		timestamp, err := pulseNumber.AsApproximateTime()
 		require.NoError(t, err)
-		pulse := models.Pulse{PulseNumber: int(pulseNumber), Timestamp: timestamp.Unix()}
+		pulse := models.Pulse{PulseNumber: int64(pulseNumber), Timestamp: timestamp.Unix()}
 		err = testutils.CreatePulse(testDB, pulse)
 		require.NoError(t, err)
 		jetDrop := testutils.InitJetDropDB(pulse)
@@ -731,8 +731,8 @@ func TestStorage_GetLifeline_TimestampRange(t *testing.T) {
 
 	expectedRecords := []models.Record{pulses[1].records[1], pulses[1].records[0], pulses[0].records[1], pulses[0].records[0]}
 
-	timestampLte := int(pulses[1].pulse.Timestamp)
-	timestampGte := int(pulses[0].pulse.Timestamp)
+	timestampLte := int64(pulses[1].pulse.Timestamp)
+	timestampGte := int64(pulses[0].pulse.Timestamp)
 	records, total, err := s.GetLifeline(
 		pulses[1].records[0].ObjectReference, nil,
 		nil, nil, &timestampLte, &timestampGte, 20, 0, false)
@@ -936,7 +936,7 @@ func TestStorage_GetPulse_PulseWithRecords(t *testing.T) {
 func TestStorage_GetPulse_NotExist(t *testing.T) {
 	s := NewStorage(testDB)
 
-	_, _, _, err := s.GetPulse(int(gen.PulseNumber()))
+	_, _, _, err := s.GetPulse(int64(gen.PulseNumber()))
 	require.Error(t, err)
 	require.True(t, gorm.IsRecordNotFoundError(err))
 }
@@ -1461,7 +1461,7 @@ func TestStorage_GetNextSavedPulse(t *testing.T) {
 	s := NewStorage(testDB)
 
 	pulse := models.Pulse{
-		PulseNumber: int(gen.PulseNumber().AsUint32()),
+		PulseNumber: int64(gen.PulseNumber().AsUint32()),
 	}
 	expectedPulse := models.Pulse{
 		PulseNumber: pulse.PulseNumber + 10,

--- a/etl/transformer/transformer.go
+++ b/etl/transformer/transformer.go
@@ -188,7 +188,7 @@ func getPulseData(rec *exporter.Record) (types.Pulse, error) {
 		return types.Pulse{}, errors.Wrapf(err, "could not get pulse ApproximateTime. pulse: %v", pulse.String())
 	}
 	return types.Pulse{
-		PulseNo:        int(pulse.AsUint32()),
+		PulseNo:        int64(pulse.AsUint32()),
 		EpochPulseNo:   int(pulse.AsEpoch()),
 		PulseTimestamp: time.Unix(),
 		NextPulseDelta: int(pulseDelta),

--- a/etl/types/types.go
+++ b/etl/types/types.go
@@ -54,7 +54,7 @@ type DropContinue struct {
 }
 
 type Pulse struct {
-	PulseNo        int
+	PulseNo        int64
 	EpochPulseNo   int
 	PulseTimestamp int64
 	NextPulseDelta int

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -15,20 +15,20 @@ import (
 func Migrations() []*gormigrate.Migration {
 	return []*gormigrate.Migration{
 		{
-			ID: "202005180423",
+			ID: "202005180421",
 			Migrate: func(tx *gorm.DB) error {
 				// the initial database tables. Do not delete it's
 				type Pulse struct {
-					PulseNumber     int `gorm:"primary_key;auto_increment:false"`
-					PrevPulseNumber int
-					NextPulseNumber int
+					PulseNumber     int64 `gorm:"primary_key;auto_increment:false"`
+					PrevPulseNumber int64
+					NextPulseNumber int64
 					IsComplete      bool
 					IsSequential    bool
 					Timestamp       int64
 				}
 				type JetDrop struct {
 					JetID          string `gorm:"type:varchar(255);primary_key;auto_increment:false;default:''"`
-					PulseNumber    int    `gorm:"primary_key;auto_increment:false"`
+					PulseNumber    int64  `gorm:"primary_key;auto_increment:false"`
 					FirstPrevHash  []byte
 					SecondPrevHash []byte
 					Hash           []byte
@@ -46,7 +46,7 @@ func Migrations() []*gormigrate.Migration {
 					Hash                []byte
 					RawData             []byte
 					JetID               string
-					PulseNumber         int
+					PulseNumber         int64
 					Order               int
 					Timestamp           int64
 				}

--- a/test/api/jd_by_id_test.go
+++ b/test/api/jd_by_id_test.go
@@ -87,7 +87,7 @@ func TestGetJetDropsByID_negativeCases(t *testing.T) {
 		records[2].Record.ID.Pulse())
 	invalidJetID := "0qwerty123:!@#$%^"
 	withBigLengthPrefix := fmt.Sprintf("%v:%v",
-		strings.Repeat(jetDropID, 20),
+		strings.Repeat("01", 130),
 		records[0].Record.ID.Pulse())
 	withBigLengthPulse := fmt.Sprintf("%v:%v",
 		strings.Split(converter.JetIDToString(records[0].Record.JetID), ":")[0],

--- a/test/api/object_lifeline_test.go
+++ b/test/api/object_lifeline_test.go
@@ -70,7 +70,7 @@ func TestLifeline_severalPulses(t *testing.T) {
 	err := heavymock.ImportRecords(ts.ConMngr.ImporterClient, records)
 	require.NoError(t, err)
 
-	ts.WaitRecordsCount(t, len(lifelineRecords), 1000)
+	ts.WaitRecordsCount(t, len(lifelineRecords), 5000)
 
 	c := GetHTTPClient()
 	response, err := c.ObjectLifeline(t, lifeline.ObjID.String(), &client.ObjectLifelineOpts{Limit: optional.NewInt32(100)})

--- a/test/integration/db_integration_test.go
+++ b/test/integration/db_integration_test.go
@@ -102,9 +102,9 @@ func TestIntegrationWithDb_GetJetDrops(t *testing.T) {
 	expRecords = append(expRecords, expRecordsJet1...)
 	expRecords = append(expRecords, expRecordsJet2...)
 
-	pulseNumbers := map[int]bool{}
+	pulseNumbers := map[int64]bool{}
 	for _, r := range expRecords {
-		pulseNumbers[int(r.Record.ID.Pulse())] = true
+		pulseNumbers[int64(r.Record.ID.Pulse())] = true
 	}
 
 	err := heavymock.ImportRecords(ts.ConMngr.ImporterClient, expRecords)

--- a/testutils/canonical.go
+++ b/testutils/canonical.go
@@ -18,7 +18,7 @@ func CreateJetDropCanonical(records []types.Record) types.JetDrop {
 		MainSection: &types.MainSection{
 			Start: types.DropStart{
 				PulseData: types.Pulse{
-					PulseNo:        int(gen.PulseNumber()),
+					PulseNo:        int64(gen.PulseNumber()),
 					PrevPulseDelta: 10,
 					NextPulseDelta: 10,
 				},

--- a/testutils/models.go
+++ b/testutils/models.go
@@ -84,25 +84,25 @@ func InitPulseDB() (models.Pulse, error) {
 		return models.Pulse{}, err
 	}
 	return models.Pulse{
-		PulseNumber:     int(pulseNumber.AsUint32()),
-		PrevPulseNumber: int(pulseNumber.Prev(pulseDelta)),
-		NextPulseNumber: int(pulseNumber.Next(pulseDelta)),
+		PulseNumber:     int64(pulseNumber.AsUint32()),
+		PrevPulseNumber: int64(pulseNumber.Prev(pulseDelta)),
+		NextPulseNumber: int64(pulseNumber.Next(pulseDelta)),
 		IsComplete:      false,
 		Timestamp:       timestamp.Unix(),
 	}, nil
 }
 
 // InitNextPulseDB returns generated pulse after pn
-func InitNextPulseDB(pn int) (models.Pulse, error) {
-	pulseNumber := insolar.PulseNumber(pn + int(pulseDelta))
+func InitNextPulseDB(pn int64) (models.Pulse, error) {
+	pulseNumber := insolar.PulseNumber(pn + int64(pulseDelta))
 	timestamp, err := pulseNumber.AsApproximateTime()
 	if err != nil {
 		return models.Pulse{}, err
 	}
 	return models.Pulse{
-		PulseNumber:     int(pulseNumber.AsUint32()),
-		PrevPulseNumber: int(pulseNumber.Prev(pulseDelta)),
-		NextPulseNumber: int(pulseNumber.Next(pulseDelta)),
+		PulseNumber:     int64(pulseNumber.AsUint32()),
+		PrevPulseNumber: int64(pulseNumber.Prev(pulseDelta)),
+		NextPulseNumber: int64(pulseNumber.Next(pulseDelta)),
 		IsComplete:      false,
 		Timestamp:       timestamp.Unix(),
 	}, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
chnage the pulsenumber as int64 because integer in the DB can be 2147483647 but PN can be 4294967295 (2times more). that's why we need to store int64, and GORM will concert that as bigint. 

So, not to convert all the time int to int64 I changed pulsenumber from API handler to DB store with tests. 

**- How I did it**
change int to int64

**- How to verify it**
with tests and after migration. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
