### PR TITLE
PENV-458: set correct jet id for db search

### DIFF
--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -1090,7 +1090,7 @@ func TestServer_JetDropByID(t *testing.T) {
 		jetDrop1.JetID = converter.JetIDToString(jetID1)
 		err = testutils.CreateJetDrop(testDB, jetDrop1)
 		require.NoError(t, err)
-		jetDropID1 := models.NewJetDropID(jetDrop1.JetID, int64(pulse.PulseNumber)).ToString()
+		jetDropID1 := models.NewJetDropID(jetDrop1.JetID, int64(pulse.PulseNumber))
 
 		jetDrop3 := testutils.InitJetDropDB(pulse)
 		jetID3 := jet.NewIDFromString("010")
@@ -1098,7 +1098,7 @@ func TestServer_JetDropByID(t *testing.T) {
 		err = testutils.CreateJetDrop(testDB, jetDrop3)
 		require.NoError(t, err)
 
-		resp, err := http.Get("http://" + apihost + "/api/v1/jet-drops/" + jetDropID1)
+		resp, err := http.Get("http://" + apihost + "/api/v1/jet-drops/" + jetDropID1.ToString())
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
@@ -1107,7 +1107,8 @@ func TestServer_JetDropByID(t *testing.T) {
 		var received server.JetDropResponse
 		err = json.Unmarshal(bodyBytes, &received)
 		require.NoError(t, err)
-		require.Equal(t, jetDropID1, *received.JetDropId)
+		require.Equal(t, jetDropID1.ToString(), *received.JetDropId)
+		require.Equal(t, jetDropID1.JetIDToString(), *received.JetId)
 		require.Equal(t, base64.StdEncoding.EncodeToString(jetDrop1.Hash), *received.Hash)
 	})
 
@@ -1125,9 +1126,9 @@ func TestServer_JetDropByID(t *testing.T) {
 		jetDrop1.JetID = converter.JetIDToString(jetID1)
 		err = testutils.CreateJetDrop(testDB, jetDrop1)
 		require.NoError(t, err)
-		jetDropID1 := models.NewJetDropID(jetDrop1.JetID, int64(pulse.PulseNumber)).ToString()
+		jetDropID1 := models.NewJetDropID(jetDrop1.JetID, int64(pulse.PulseNumber))
 
-		resp, err := http.Get("http://" + apihost + "/api/v1/jet-drops/" + jetDropID1)
+		resp, err := http.Get("http://" + apihost + "/api/v1/jet-drops/" + jetDropID1.ToString())
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
@@ -1136,7 +1137,8 @@ func TestServer_JetDropByID(t *testing.T) {
 		var received server.JetDropResponse
 		err = json.Unmarshal(bodyBytes, &received)
 		require.NoError(t, err)
-		require.Equal(t, jetDropID1, *received.JetDropId)
+		require.Equal(t, jetDropID1.ToString(), *received.JetDropId)
+		require.Equal(t, jetDropID1.JetIDToString(), *received.JetId)
 		require.Equal(t, base64.StdEncoding.EncodeToString(jetDrop1.Hash), *received.Hash)
 	})
 
@@ -1259,9 +1261,9 @@ func TestServer_JetDropByID(t *testing.T) {
 		jetDrop1.JetID = converter.JetIDToString(jetID1)
 		err = testutils.CreateJetDrop(testDB, jetDrop1)
 		require.NoError(t, err)
-		jetDropID1 := models.NewJetDropID(jetDrop1.JetID, int64(pulse.PulseNumber)).ToString()
+		jetDropID1 := models.NewJetDropID(jetDrop1.JetID, int64(pulse.PulseNumber))
 
-		urlencoded := url.QueryEscape(jetDropID1)
+		urlencoded := url.QueryEscape(jetDropID1.ToString())
 		resp, err := http.Get("http://" + apihost + "/api/v1/jet-drops/" + urlencoded)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1271,7 +1273,8 @@ func TestServer_JetDropByID(t *testing.T) {
 		var received server.JetDropResponse
 		err = json.Unmarshal(bodyBytes, &received)
 		require.NoError(t, err)
-		require.Equal(t, jetDropID1, *received.JetDropId)
+		require.Equal(t, jetDropID1.ToString(), *received.JetDropId)
+		require.Equal(t, jetDropID1.JetIDToString(), *received.JetId)
 		require.Equal(t, base64.StdEncoding.EncodeToString(jetDrop1.Hash), *received.Hash)
 	})
 

--- a/api/mappers.go
+++ b/api/mappers.go
@@ -26,7 +26,7 @@ func RecordToAPI(record models.Record) server.Record {
 	response := server.Record{
 		Hash:        NullableString(base64.StdEncoding.EncodeToString(record.Hash)),
 		JetDropId:   NullableString(jetDropID.ToString()),
-		JetId:       NullableString(jetDropID.JetID),
+		JetId:       NullableString(jetDropID.JetIDToString()),
 		Index:       NullableString(fmt.Sprintf("%d:%d", record.PulseNumber, record.Order)),
 		Payload:     NullableString(base64.StdEncoding.EncodeToString(record.Payload)),
 		PulseNumber: &pulseNumber,
@@ -88,7 +88,7 @@ func JetDropToAPI(jetDrop models.JetDrop) server.JetDrop {
 	result := server.JetDrop{
 		Hash:      NullableString(base64.StdEncoding.EncodeToString(jetDrop.Hash)),
 		JetDropId: NullableString(jetDropID.ToString()),
-		JetId:     NullableString(jetDropID.JetID),
+		JetId:     NullableString(jetDropID.JetIDToString()),
 		// todo implement this if needed
 		NextJetDropId: &nextJetDropID,
 		PrevJetDropId: &prevJetDropID,

--- a/etl/models/models.go
+++ b/etl/models/models.go
@@ -75,8 +75,8 @@ type JetDropID struct {
 
 func NewJetDropID(jetID string, pulseNumber int64) *JetDropID {
 	tmp := jetID
-	if jetID == "" {
-		tmp = "*"
+	if jetID == "*" {
+		tmp = ""
 	}
 	return &JetDropID{JetID: tmp, PulseNumber: pulseNumber}
 }
@@ -84,6 +84,7 @@ func NewJetDropID(jetID string, pulseNumber int64) *JetDropID {
 // jetIDRegexp uses for a validation of the JetID
 var jetIDRegexp = regexp.MustCompile(`^(\*|([0-1]{1,216}))$`)
 
+// NewJetDropIDFromString create JetDropID from provided string representation. Jet with empty prefix returned with empty jetID.
 func NewJetDropIDFromString(jetDropID string) (*JetDropID, error) {
 	var pulse int64
 	jetDropID, err := url.QueryUnescape(jetDropID)
@@ -106,5 +107,13 @@ func NewJetDropIDFromString(jetDropID string) (*JetDropID, error) {
 }
 
 func (j *JetDropID) ToString() string {
-	return fmt.Sprintf("%s:%d", j.JetID, j.PulseNumber)
+	return fmt.Sprintf("%s:%d", j.JetIDToString(), j.PulseNumber)
+}
+
+func (j *JetDropID) JetIDToString() string {
+	tmp := j.JetID
+	if j.JetID == "" {
+		tmp = "*"
+	}
+	return tmp
 }


### PR DESCRIPTION
**- What I did**
-  for first jet with depth=0 `JetDropID` func return jet with empty jetID
- to return result to API, use `ToString` and `JetIDToString` methods of `JetDropID`

**- How to verify it**
Run tests