### PR TITLE
PENV-463: set objectReference depends on record pulse

### DIFF
--- a/test/api/search_test.go
+++ b/test/api/search_test.go
@@ -38,7 +38,7 @@ func TestSearchApi(t *testing.T) {
 	lifeline := testutils.GenerateObjectLifeline(pulsesCount, recordsCount)
 	records := lifeline.GetAllRecords()
 	require.NoError(t, heavymock.ImportRecords(ts.ConMngr.ImporterClient, records))
-	ts.WaitRecordsCount(t, len(records)-recordsCount, 5000)
+	ts.WaitRecordsCount(t, len(records)-1, 5000)
 	c := GetHTTPClient()
 
 	record := lifeline.GetStateRecords()[0]


### PR DESCRIPTION
**- What I did**
Change logic for setting objectReference in transformer.
Activate record is state record, so logic of lifeline creation in testutils was changed too.

**- How to verify it**
Run tests
