### PR TITLE
PENV-421: fix flaky test TestStorage_GetJetDropsByJetId_Fail

### DIFF
--- a/etl/storage/storage_test.go
+++ b/etl/storage/storage_test.go
@@ -1546,8 +1546,8 @@ func TestStorage_GetJetDropsByJetId_Fail(t *testing.T) {
 	err = testutils.CreatePulse(testDB, secondPulse)
 	require.NoError(t, err)
 
-	notExistEdJetID := "100"
-	jetDrops, total, err := s.GetJetDropsByJetID(notExistEdJetID, nil, nil, nil, nil, -1, true)
+	notExistingJetID := "100"
+	jetDrops, total, err := s.GetJetDropsByJetID(notExistingJetID, nil, nil, nil, nil, -1, true)
 	require.NoError(t, err)
 	require.Len(t, jetDrops, 0)
 	require.Equal(t, 0, total)

--- a/etl/storage/storage_test.go
+++ b/etl/storage/storage_test.go
@@ -1532,10 +1532,12 @@ func TestStorage_GetJetDropsByJetId_Fail(t *testing.T) {
 	require.NoError(t, err)
 
 	jetDropForFirstPulse1 := testutils.InitJetDropDB(firstPulse)
+	jetDropForFirstPulse1.JetID = "000"
 	err = testutils.CreateJetDrop(testDB, jetDropForFirstPulse1)
 	require.NoError(t, err)
 
 	jetDropForFirstPulse2 := testutils.InitJetDropDB(firstPulse)
+	jetDropForFirstPulse2.JetID = "001"
 	err = testutils.CreateJetDrop(testDB, jetDropForFirstPulse2)
 	require.NoError(t, err)
 
@@ -1543,10 +1545,9 @@ func TestStorage_GetJetDropsByJetId_Fail(t *testing.T) {
 	require.NoError(t, err)
 	err = testutils.CreatePulse(testDB, secondPulse)
 	require.NoError(t, err)
-	jetDropForSecondPulse := testutils.InitJetDropDB(secondPulse)
 
-	wrongJetID := jetDropForSecondPulse.JetID
-	jetDrops, total, err := s.GetJetDropsByJetID(wrongJetID, nil, nil, nil, nil, -1, true)
+	notExistEdJetID := "100"
+	jetDrops, total, err := s.GetJetDropsByJetID(notExistEdJetID, nil, nil, nil, nil, -1, true)
 	require.NoError(t, err)
 	require.Len(t, jetDrops, 0)
 	require.Equal(t, 0, total)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fix flaky test 

**- How I did it**
sometimes the generator returns a jetId with parent and child. that why the test method could find them. 
Now, all jetid is different. and it's really wrong JETID which does not exist in DB
**- How to verify it**
go test -v ./etl/storage -tags integration -run "^TestStorage_GetJetDropsByJetId_Fail$" -count=1000 -failfast

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
