### PR TITLE
PENV-440 split jetdrops tests

### DIFF
--- a/testutils/generators.go
+++ b/testutils/generators.go
@@ -391,6 +391,7 @@ func GenerateRecordsWIthSplitJetDrops(pn insolar.PulseNumber, depth int, records
 			for _, r := range records {
 				r.Record.ID = gen.IDWithPulse(p)
 				r.Record.JetID = jd
+				r.ShouldIterateFrom = nil
 			}
 			result = append(result, records...)
 		}

--- a/testutils/generators.go
+++ b/testutils/generators.go
@@ -400,7 +400,7 @@ func GenerateRecordsWIthSplitJetDrops(pn insolar.PulseNumber, depth int, records
 	return result, jdTree
 }
 
-// Generate map of pulses and related list of splitted JetDrops
+// Generate tree of splitted JetDrops with specified depth
 func GenerateJetIDTree(pn insolar.PulseNumber, depth int) map[insolar.PulseNumber]map[insolar.JetID][][]byte {
 	timeout := time.After(5 * time.Second)
 	result := make(map[insolar.PulseNumber]map[insolar.JetID][][]byte)

--- a/testutils/generators.go
+++ b/testutils/generators.go
@@ -190,7 +190,7 @@ func GenerateObjectLifeline(pulseCount, recordsInPulse int) ObjectLifeline {
 		if len(amends) > 0 {
 			prevState = amends[len(amends)-1].Record.ID
 		}
-		if i == pulseCount-1 {
+		if i == pulseCount-1 && recordsInPulse > 1 {
 			prevState = amends[len(amends)-2].Record.ID
 			deactivate := GenerateVirtualDeactivateRecord(pn, objectID, prevState)
 			deactivate.Record.JetID = jetID
@@ -372,6 +372,11 @@ func RandomString(n int) string {
 	return string(b)
 }
 
+// generate records with split JetDrops
+func GenerateRecordsWithSplitJetDrops(t *testing.T) {
+
+}
+
 // GenerateJetDropsWithSplit returns a jetdrops with splited by depth in different pulse
 func GenerateJetDropsWithSplit(t *testing.T, pulseCount, jDCount int, depth int) ([]models.JetDrop, []models.Pulse) {
 	pulses := make([]models.Pulse, pulseCount)
@@ -427,5 +432,3 @@ func createChildren(pulse models.Pulse, jetID string, depth int) []models.JetDro
 	drops = append(drops, createChildren(pulse, right, depth-1)...)
 	return drops
 }
-
-// func Generate

--- a/testutils/generators.go
+++ b/testutils/generators.go
@@ -190,15 +190,12 @@ func GenerateObjectLifeline(pulseCount, recordsInPulse int) ObjectLifeline {
 		if len(amends) > 0 {
 			prevState = amends[len(amends)-1].Record.ID
 		}
-		// TODO uncomment after resolving https://insolar.atlassian.net/browse/PENV-368
-		// if i == pulseCount-1 {
-		// 	deactivate := GenerateVirtualDeactivateRecord(pn, objectID, prevState)
-		// 	deactivate.Record.JetID = jetID
-		// 	sideRecords[1] = RecordsByPulse{
-		// 		Pn:      pn,
-		// 		Records: []*exporter.Record{deactivate},
-		// 	}
-		// }
+		if i == pulseCount-1 {
+			prevState = amends[len(amends)-2].Record.ID
+			deactivate := GenerateVirtualDeactivateRecord(pn, objectID, prevState)
+			deactivate.Record.JetID = jetID
+			records[len(records)-1] = deactivate
+		}
 
 		stateRecords[i] = RecordsByPulse{
 			Pn:      pn,
@@ -430,3 +427,5 @@ func createChildren(pulse models.Pulse, jetID string, depth int) []models.JetDro
 	drops = append(drops, createChildren(pulse, right, depth-1)...)
 	return drops
 }
+
+// func Generate

--- a/testutils/generators.go
+++ b/testutils/generators.go
@@ -381,6 +381,23 @@ func RandomString(n int) string {
 	return string(b)
 }
 
+// generate records with split JetDrops
+func GenerateRecordsWIthSplitJetDrops(pn insolar.PulseNumber, depth int, recordsInJetDrop int) []*exporter.Record {
+	result := make([]*exporter.Record, 0)
+	jdTree := GenerateJetIDTree(pn, depth)
+	for p, jds := range jdTree {
+		for _, jd := range jds {
+			records := GenerateRecordsSilence(recordsInJetDrop)
+			for _, r := range records {
+				r.Record.ID = gen.IDWithPulse(p)
+				r.Record.JetID = jd
+			}
+			result = append(result, records...)
+		}
+	}
+	return result
+}
+
 // Generate map of pulses and related list of splitted JetDrops
 func GenerateJetIDTree(pn insolar.PulseNumber, depth int) map[insolar.PulseNumber][]insolar.JetID {
 	timeout := time.After(5 * time.Second)

--- a/testutils/generators.go
+++ b/testutils/generators.go
@@ -338,14 +338,14 @@ var mutex = &sync.Mutex{}
 func GenerateUniqueJetID() insolar.JetID {
 	for {
 		jetID := gen.JetID()
-		if !isUniqueJetId(jetID) {
+		if !isUniqueJetID(jetID) {
 			continue
 		}
 		return jetID
 	}
 }
 
-func isUniqueJetId(jetID insolar.JetID) bool {
+func isUniqueJetID(jetID insolar.JetID) bool {
 	id := binary.BigEndian.Uint64(jetID.Prefix())
 	if id == 0 {
 		return false
@@ -401,7 +401,7 @@ func GenerateRecordsWIthSplitJetDrops(pn insolar.PulseNumber, depth int, records
 // Generate map of pulses and related list of splitted JetDrops
 func GenerateJetIDTree(pn insolar.PulseNumber, depth int) map[insolar.PulseNumber][]insolar.JetID {
 	timeout := time.After(5 * time.Second)
-	result := make(map[insolar.PulseNumber][]insolar.JetID, 0)
+	result := make(map[insolar.PulseNumber][]insolar.JetID)
 	for {
 		select {
 		case <-timeout:
@@ -409,7 +409,7 @@ func GenerateJetIDTree(pn insolar.PulseNumber, depth int) map[insolar.PulseNumbe
 		default:
 		}
 		rootJetID := *insolar.NewJetID(20, gen.IDWithPulse(pn).Bytes())
-		if !isUniqueJetId(rootJetID) {
+		if !isUniqueJetID(rootJetID) {
 			continue
 		}
 		result[pn] = []insolar.JetID{rootJetID}
@@ -429,7 +429,7 @@ func siblings(parent insolar.JetID, parentPn insolar.PulseNumber, depth int) map
 	}
 
 	pn := parentPn
-	result := make(map[insolar.PulseNumber][]insolar.JetID, 0)
+	result := make(map[insolar.PulseNumber][]insolar.JetID)
 	left, right := jet.Siblings(parent)
 	pn += 10
 	result[pn] = []insolar.JetID{left, right}

--- a/testutils/generators.go
+++ b/testutils/generators.go
@@ -414,13 +414,10 @@ func GenerateJetIDTree(pn insolar.PulseNumber, depth int) map[insolar.PulseNumbe
 		if !isUniqueJetID(rootJetID) {
 			continue
 		}
-		familyJetDropIDMap := make(map[insolar.JetID][][]byte)
-		prevHashFirst := GenerateRandBytes()
-		prevHashSecond := GenerateRandBytes()
-		familyJetDropIDMap[rootJetID] = [][]byte{prevHashFirst, prevHashSecond, nil}
-		result[pn] = familyJetDropIDMap
+		result[pn] = map[insolar.JetID][][]byte{}
+		result[pn][rootJetID] = [][]byte{GenerateRandBytes(), GenerateRandBytes(), nil}
 
-		childs := siblings(rootJetID, pn, depth, [][]byte{prevHashFirst, prevHashSecond})
+		childs := siblings(rootJetID, pn, depth, result[pn][rootJetID])
 		for p, c := range childs {
 			result[p] = c
 		}
@@ -439,12 +436,11 @@ func siblings(parent insolar.JetID, parentPn insolar.PulseNumber, depth int, pre
 	left, right := jet.Siblings(parent)
 	pn += 10
 
-	familyJetDropIDMap := make(map[insolar.JetID][][]byte)
-	familyJetDropIDMap[left] = [][]byte{GenerateRandBytes(), GenerateRandBytes(), prevJetDropHashes[0]}
-	familyJetDropIDMap[right] = [][]byte{GenerateRandBytes(), GenerateRandBytes(), prevJetDropHashes[1]}
-	result[pn] = familyJetDropIDMap
+	result[pn] = map[insolar.JetID][][]byte{}
+	result[pn][left] = [][]byte{GenerateRandBytes(), GenerateRandBytes(), prevJetDropHashes[0]}
+	result[pn][right] = [][]byte{GenerateRandBytes(), GenerateRandBytes(), prevJetDropHashes[1]}
 
-	l := siblings(left, pn, depth-1, familyJetDropIDMap[left])
+	l := siblings(left, pn, depth-1, result[pn][left])
 	for p, j := range l {
 		if jds := result[p]; jds == nil {
 			result[p] = j
@@ -455,7 +451,7 @@ func siblings(parent insolar.JetID, parentPn insolar.PulseNumber, depth int, pre
 			result[p] = jds
 		}
 	}
-	r := siblings(right, pn, depth-1, familyJetDropIDMap[right])
+	r := siblings(right, pn, depth-1, result[pn][right])
 	for p, j := range r {
 		if jds := result[p]; jds == nil {
 			result[p] = j

--- a/testutils/generators_test.go
+++ b/testutils/generators_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/insolar/gen"
 	ins_record "github.com/insolar/insolar/insolar/record"
 	"github.com/insolar/insolar/ledger/heavy/exporter"
 	"github.com/insolar/insolar/pulse"
@@ -219,4 +220,29 @@ func TestRandomString(t *testing.T) {
 	str := RandomString(l)
 	require.Equal(t, l, len(str))
 	require.True(t, strings.ContainsAny(string(letterRunes), str))
+}
+
+func TestGenerateJetIDTree(t *testing.T) {
+	tests := map[string]struct {
+		depth int
+		total int // (2^(depth + 1) - 1)
+	}{
+		"depth=0, total=1":  {0, 1},
+		"depth=1, total=6":  {1, 3},
+		"depth=2, total=7":  {2, 7},
+		"depth=3, total=15": {3, 15},
+		"depth=4, total=15": {4, 31},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			jDcount := 0
+			pn := gen.PulseNumber()
+			res := GenerateJetIDTree(pn, tc.depth)
+			for _, v := range res {
+				jDcount += len(v)
+			}
+			require.Equal(t, tc.total, jDcount)
+		})
+	}
 }

--- a/testutils/generators_test.go
+++ b/testutils/generators_test.go
@@ -118,6 +118,7 @@ func TestGenerateObjectLifeline(t *testing.T) {
 
 	var amendCount int
 	var activateCount int
+	var deactivateCount int
 	var unknown int
 	for _, r := range allRecords {
 		require.Equal(t, objID, r.Record.ObjectID)
@@ -128,13 +129,16 @@ func TestGenerateObjectLifeline(t *testing.T) {
 			amendCount++
 		case *ins_record.Virtual_Activate:
 			activateCount++
+		case *ins_record.Virtual_Deactivate:
+			deactivateCount++
 		default:
 			unknown++
 		}
 	}
 	require.Equal(t, 0, unknown)
-	require.Equal(t, pulsesNumber*recordsNumber-1, amendCount)
+	require.Equal(t, pulsesNumber*recordsNumber-2, amendCount) // 2 = one activate record + one deactivate record
 	require.Equal(t, 1, activateCount)
+	require.Equal(t, 1, deactivateCount)
 
 	sideRecords := make([]*exporter.Record, 0)
 	for i := 0; i < len(lifeline.SideRecords); i++ {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Generate records with its JetIDs as a splitted JetID (JetDrop) tree. 
Set Prev and Next JetDrop hashes to be processed by BE 
Using API get full array of JetDrops by root JetDropID
Check that all splitted JetDrops in the response array have Prev and/or Next JetDropIDs
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
