### PR TITLE
PENV-523: save correct jetdrop count

### DIFF
--- a/etl/extractor/platform_impl.go
+++ b/etl/extractor/platform_impl.go
@@ -101,11 +101,11 @@ func closeStream(ctx context.Context, stream exporter.RecordExporter_ExportClien
 func (e *PlatformExtractor) retrievePulses(ctx context.Context, from, until int64) {
 	pu := &exporter.FullPulse{PulseNumber: insolar.PulseNumber(from)}
 	var err error
-	log := belogger.FromContext(ctx)
+	logger := belogger.FromContext(ctx)
 
 	halfPulse := time.Duration(e.continuousPulseRetrievingHalfPulseSeconds) * time.Second
 	for {
-		log = log.WithField("pulse_number", pu.PulseNumber)
+		log := logger.WithField("pulse_number", pu.PulseNumber)
 		log.Debug("retrievePulses(): Start")
 
 		select {

--- a/etl/storage/storage.go
+++ b/etl/storage/storage.go
@@ -37,7 +37,7 @@ func (s *Storage) SaveJetDropData(jetDrop models.JetDrop, records []models.Recor
 		return nil
 	}
 	if strings.Contains(err.Error(), "error while saving jetDrop") {
-		return s.updateJD(jetDrop, records, pulseNumber)
+		return s.updateJD(jetDrop, records)
 	}
 	return err
 }
@@ -67,7 +67,7 @@ func (s *Storage) initJD(jetDrop models.JetDrop, records []models.Record, pulseN
 	})
 }
 
-func (s *Storage) updateJD(jetDrop models.JetDrop, records []models.Record, pulseNumber int64) error {
+func (s *Storage) updateJD(jetDrop models.JetDrop, records []models.Record) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		jd := &jetDrop
 		if err := tx.Save(jd).Error; err != nil {

--- a/etl/storage/storage.go
+++ b/etl/storage/storage.go
@@ -32,6 +32,42 @@ func NewStorage(db *gorm.DB) *Storage {
 // SaveJetDropData saves provided jetDrop and records to db in one transaction.
 // increase jet_drop_amount and record_amount
 func (s *Storage) SaveJetDropData(jetDrop models.JetDrop, records []models.Record, pulseNumber int64) error {
+	err := s.initJD(jetDrop, records, pulseNumber)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "error while saving jetDrop") {
+		return s.updateJD(jetDrop, records, pulseNumber)
+	}
+	return err
+}
+
+func (s *Storage) initJD(jetDrop models.JetDrop, records []models.Record, pulseNumber int64) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		jd := &jetDrop
+		if err := tx.Create(jd).Error; err != nil {
+			return errors.Wrap(err, "error while saving jetDrop")
+		}
+
+		for _, record := range records {
+			if err := tx.Save(&record).Error; err != nil { // nolint
+				return errors.Wrap(err, "error while saving record")
+			}
+		}
+
+		err := tx.Model(&models.Pulse{PulseNumber: pulseNumber}).
+			UpdateColumns(map[string]interface{}{
+				"jet_drop_amount": gorm.Expr("jet_drop_amount + ?", 1),
+				"record_amount":   gorm.Expr("record_amount + ?", len(records)),
+			}).Error
+		if err != nil {
+			return errors.Wrap(err, "error to update pulse data")
+		}
+		return nil
+	})
+}
+
+func (s *Storage) updateJD(jetDrop models.JetDrop, records []models.Record, pulseNumber int64) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		jd := &jetDrop
 		if err := tx.Save(jd).Error; err != nil {
@@ -43,14 +79,6 @@ func (s *Storage) SaveJetDropData(jetDrop models.JetDrop, records []models.Recor
 				return errors.Wrap(err, "error while saving record")
 			}
 		}
-
-		err := tx.Model(&models.Pulse{PulseNumber: pulseNumber}).
-			UpdateColumn("jet_drop_amount", gorm.Expr("jet_drop_amount + ?", 1)).
-			UpdateColumn("record_amount", gorm.Expr("record_amount + ?", len(records))).Error
-
-		if err != nil {
-			return errors.Wrap(err, "error to update pulse data")
-		}
 		return nil
 	})
 }
@@ -59,7 +87,11 @@ func (s *Storage) SaveJetDropData(jetDrop models.JetDrop, records []models.Recor
 func (s *Storage) SavePulse(pulse models.Pulse) error {
 	s.savePulseLock.Lock()
 	defer s.savePulseLock.Unlock()
-	return errors.Wrap(s.db.Save(&pulse).Error, "error while saving pulse")
+	err := s.db.Set("gorm:insert_option", ""+
+		"ON CONFLICT (pulse_number) DO UPDATE SET prev_pulse_number=EXCLUDED.prev_pulse_number, "+
+		"next_pulse_number=EXCLUDED.next_pulse_number, timestamp=EXCLUDED.timestamp",
+	).Create(&pulse).Error
+	return errors.Wrap(err, "error while saving pulse")
 }
 
 // CompletePulse update pulse with provided number to completeness in db.

--- a/test/api/jd_by_jetid_test.go
+++ b/test/api/jd_by_jetid_test.go
@@ -160,7 +160,14 @@ func TestGetJetDropsByJetID_queryParams(t *testing.T) {
 	sortkeys.Uint32s(uniqPulses)
 	jetID := converter.JetIDToString(records[0].Record.JetID)
 	require.NoError(t, heavymock.ImportRecords(ts.ConMngr.ImporterClient, records))
-	require.NoError(t, heavymock.ImportRecords(ts.ConMngr.ImporterClient, []*exporter.Record{testutils.GenerateRecordInNextPulse(maxPn)}))
+	// jetID in next pulse must not be related to test jetID
+	var nextPulseJetID string
+	var record *exporter.Record
+	for strings.HasPrefix(nextPulseJetID, jetID) || strings.HasPrefix(jetID, nextPulseJetID) {
+		record = testutils.GenerateRecordInNextPulse(maxPn)
+		nextPulseJetID = converter.JetIDToString(record.Record.JetID)
+	}
+	require.NoError(t, heavymock.ImportRecords(ts.ConMngr.ImporterClient, []*exporter.Record{record}))
 
 	ts.BE.PulseClient.SetNextFinalizedPulseFunc(ts.ConMngr.Importer)
 	ts.StartBE(t)

--- a/test/integration/db_integration_test.go
+++ b/test/integration/db_integration_test.go
@@ -266,7 +266,7 @@ func TestIntegrationWithDb_GetJetDrops(t *testing.T) {
 }
 
 func TestIntegrationWithDb_GetPulse(t *testing.T) {
-	t.Log("CXXXX Process records and get saved pulses by pulse number from database")
+	t.Log("C5648 Process records and get saved pulses by pulse number from database")
 
 	ts := NewBlockExplorerTestSetup(t)
 	defer ts.Stop(t)
@@ -315,7 +315,7 @@ func TestIntegrationWithDb_GetPulse(t *testing.T) {
 // save data for first pulse again, change PrevPulseNumber and jetDrops hashes to new values
 // check pulse in db have new value at PrevPulseNumber
 func TestIntegrationWithDb_GetPulse_ReloadData(t *testing.T) {
-	t.Log("CXXXX Process records twice (as if reloading data happened) and get saved pulse by pulse number from database")
+	t.Log("C5649 Process records twice (as if reloading data happened) and get saved pulse by pulse number from database")
 
 	ts := NewBlockExplorerTestSetup(t)
 	defer ts.Stop(t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- If pulse was already saved, don't update system fields for it
- if jetDrop was already set, don't update `jet_drop_amount` and `record_amount` at corresponding pulse
- Add integration tests to check pulse at db in normal conditions and if data for pulse was load twice

**- How to verify it**
Run tests
