### PR TITLE
PENV-525: make copy of jetDropRegister to unlock adding to it, reload…

### DIFF
--- a/etl/controller/pulsemaintainer.go
+++ b/etl/controller/pulsemaintainer.go
@@ -192,7 +192,6 @@ Main:
 }
 
 func (c *Controller) reloadData(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) {
-	return
 	log := belogger.FromContext(ctx)
 	if fromPulseNumber == 0 {
 		fromPulseNumber = pulse.MinTimePulse - 1

--- a/etl/controller/pulsemaintainer.go
+++ b/etl/controller/pulsemaintainer.go
@@ -33,11 +33,18 @@ func (c *Controller) pulseMaintainer(ctx context.Context) {
 }
 
 func eraseJetDropRegister(ctx context.Context, c *Controller, log log.Logger) {
-	c.jetDropRegisterLock.Lock()
-	defer c.jetDropRegisterLock.Unlock()
+	jetDropRegisterCopy := map[types.Pulse]map[string]struct{}{}
+	func() {
+		c.jetDropRegisterLock.Lock()
+		defer c.jetDropRegisterLock.Unlock()
+		for k, v := range c.jetDropRegister {
+			jetDropRegisterCopy[k] = v
+		}
+	}()
 
-	for p, d := range c.jetDropRegister {
+	for p, d := range jetDropRegisterCopy {
 		if pulseIsComplete(p, d) {
+			log.Infof("Pulse %d completed, update it in db", p.PulseNo)
 			if func() bool {
 
 				if err := c.storage.CompletePulse(p.PulseNo); err != nil {
@@ -45,14 +52,18 @@ func eraseJetDropRegister(ctx context.Context, c *Controller, log log.Logger) {
 					return false
 				}
 
-				delete(c.jetDropRegister, p)
+				func() {
+					c.jetDropRegisterLock.Lock()
+					defer c.jetDropRegisterLock.Unlock()
+					delete(c.jetDropRegister, p)
+				}()
 				return true
 
 			}() {
 				log.Infof("Pulse %d completed and saved", p.PulseNo)
 			}
 		} else {
-			c.reloadData(ctx, p.PrevPulseNumber, p.PulseNo)
+			go c.reloadData(ctx, p.PrevPulseNumber, p.PulseNo)
 		}
 	}
 }

--- a/etl/extractor/platform_pulse.go
+++ b/etl/extractor/platform_pulse.go
@@ -8,9 +8,10 @@ package extractor
 import (
 	"context"
 
-	"github.com/insolar/block-explorer/instrumentation/belogger"
 	"github.com/insolar/insolar/ledger/heavy/exporter"
 	"github.com/pkg/errors"
+
+	"github.com/insolar/block-explorer/instrumentation/belogger"
 )
 
 type PlatformPulseExtractor struct {
@@ -49,7 +50,7 @@ func (ppe *PlatformPulseExtractor) GetNextFinalizedPulse(ctx context.Context, p 
 	req := &exporter.GetNextFinalizedPulse{p} // nolint
 
 	log := belogger.FromContext(ctx)
-	log.Debug("GetNextFinalizedPulse")
+	log.WithField("pulse_number", p).Debug("GetNextFinalizedPulse")
 
 	// fatal error: signal_recv: inconsistent state
 	ret, err := c.NextFinalizedPulse(ctx, req)

--- a/etl/transformer/transformer.go
+++ b/etl/transformer/transformer.go
@@ -34,15 +34,12 @@ func Transform(ctx context.Context, jd *types.PlatformJetDrops) ([]*types.JetDro
 		return nil, err
 	}
 
-	log := belogger.FromContext(ctx).WithField("service", "transformer")
 	for _, jet := range jd.Pulse.Jets {
 		jetid := jet.JetID
 		if _, ok := m[jetid]; ok {
-			log.Debug("full ", jetid.DebugString())
 			continue
 		}
 		m[jetid] = nil
-		log.Debug("empty ", jetid.DebugString())
 	}
 
 	result := make([]*types.JetDrop, 0)


### PR DESCRIPTION
**- What I did**
- make copy of `jetDropRegister` to unlock adding to it (now processor's workers won't be waiting for `jetDropRegisterLock` to tell controller they save drop)
- reload data if pulse is not complete in goroutine - now controller will check next pulse without waiting data to reload (or extractor's workers to became free)
- remove some not informative logs

