### PR TITLE
PENV-579: restrict logger output for jetdrop's by jetid endpoint

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -234,7 +234,23 @@ func (s *Server) JetDropsByJetID(ctx echo.Context, jetID server.JetIdPath, param
 		if err != nil {
 			return ctx.JSON(http.StatusInternalServerError, "imposible situation")
 		}
-		s.logger.Debug(prevJetDropsFirstElem, prevJetDropsLastElem, nextJetDropsLastElem, nextJetDropsFirstElem)
+
+		logCustomFields := func(logFormatFunction func(fmt string, args ...interface{}), jetDrops []models.JetDrop) {
+			custom := make([]models.JetDrop, len(jetDrops))
+			for i, jetDrop := range jetDrops {
+				custom[i] = models.JetDrop{
+					PulseNumber:  jetDrop.PulseNumber,
+					JetID:        jetDrop.JetID,
+					Timestamp:    jetDrop.Timestamp,
+					RecordAmount: jetDrop.RecordAmount,
+				}
+			}
+			logFormatFunction("%+v", custom)
+		}
+		logCustomFields(s.logger.Debugf, prevJetDropsFirstElem)
+		logCustomFields(s.logger.Debugf, prevJetDropsLastElem)
+		logCustomFields(s.logger.Debugf, nextJetDropsLastElem)
+		logCustomFields(s.logger.Debugf, nextJetDropsFirstElem)
 	}
 
 	enrichJetDrops := func(jd []models.JetDrop) []models.JetDrop {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
restricted logger output for jetdrop's by jetid endpoint because of logger consumed a lot 

**- How I did it**
log models.JetDrop structure without hashes 

**- How to verify it**
run api locally 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
