### PR TITLE
PENV-550: dont log expected error, set belogger to db, update config …

### DIFF
--- a/cmd/block-explorer/main.go
+++ b/cmd/block-explorer/main.go
@@ -115,6 +115,8 @@ func main() {
 		}
 	}()
 
+	db.SetLogger(belogger.NewGORMLogAdapter(logger))
+
 	r := plugins.NewDefaultShutdownPlugin(stopChannel)
 	r.Apply(db)
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -61,7 +61,7 @@ type Replicator struct {
 
 // Metrics represents a configuration for expose metrics
 type Metrics struct {
-	HTTPServerPort  uint32        `insconfig:":8081| http server port"`
+	HTTPServerPort  uint32        `insconfig:"8081| http server port"`
 	RefreshInterval time.Duration `insconfig:"10s| Refresh metrics interval"`
 	StartServer     bool          `insconfig:"true| if true, create http server to expose metrics"`
 }

--- a/etl/storage/storage.go
+++ b/etl/storage/storage.go
@@ -49,7 +49,7 @@ func (s *Storage) SaveJetDropData(jetDrop models.JetDrop, records []models.Recor
 func (s *Storage) initJD(jetDrop models.JetDrop, records []models.Record, pulseNumber int64) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		jd := &jetDrop
-		transaction := *tx
+		transaction := tx.New()
 		if err := transaction.LogMode(false).Create(jd).Error; err != nil {
 			return errors.Wrap(err, "error while saving jetDrop")
 		}

--- a/etl/storage/storage.go
+++ b/etl/storage/storage.go
@@ -49,7 +49,8 @@ func (s *Storage) SaveJetDropData(jetDrop models.JetDrop, records []models.Recor
 func (s *Storage) initJD(jetDrop models.JetDrop, records []models.Record, pulseNumber int64) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		jd := &jetDrop
-		if err := tx.Create(jd).Error; err != nil {
+		transaction := *tx
+		if err := transaction.LogMode(false).Create(jd).Error; err != nil {
 			return errors.Wrap(err, "error while saving jetDrop")
 		}
 


### PR DESCRIPTION
**- What I did**
- don't log error in jetDrop creation (in this case we do update)
- use belogger in db
- minor update of default value at metrics config

**- How to verify it**
Run `TestStorage_SaveJetDropData_UpdateExistedJetDrop` test and see no log in output; run some test with other errors (`TestStorage_SaveJetDropData_RecordError_NilPK` or `TestStorage_SaveJetDropData_ErrorAtTransaction`), see error log.
