### PR TITLE
NOISSUE: set sequential pulse faster

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,15 +40,15 @@ jobs:
     env:
       GOPATH: /home/runner/work/block-explorer/block-explorer/go
     steps:
-      - name: set pull_request run params
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
-        run: |
-          echo "::set-env name=TEST_COUNT::10"
+#      - name: set pull_request run params
+#        if: github.event_name == 'pull_request' || github.event_name == 'push'
+#        run: |
+#          echo "::set-env name=TEST_COUNT::10"
       - name: set scheduled run params
-        if: github.event_name == 'schedule'
+#        if: github.event_name == 'schedule'
         run: |
           echo "::set-env name=TEST_COUNT::1000"
-          echo "::set-env name=TEST_ARGS::-timeout 60m"
+          echo "::set-env name=TEST_ARGS::-timeout 120m"
       - name: set up go ${{env.GO_VERSION}}
         uses: actions/setup-go@v1
         id: go

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,12 +40,12 @@ jobs:
     env:
       GOPATH: /home/runner/work/block-explorer/block-explorer/go
     steps:
-#      - name: set pull_request run params
-#        if: github.event_name == 'pull_request' || github.event_name == 'push'
-#        run: |
-#          echo "::set-env name=TEST_COUNT::10"
+      - name: set pull_request run params
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        run: |
+          echo "::set-env name=TEST_COUNT::10"
       - name: set scheduled run params
-#        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         run: |
           echo "::set-env name=TEST_COUNT::1000"
           echo "::set-env name=TEST_ARGS::-timeout 120m"

--- a/etl/controller/pulsemaintainer.go
+++ b/etl/controller/pulsemaintainer.go
@@ -68,7 +68,7 @@ func eraseJetDropRegister(ctx context.Context, c *Controller, log log.Logger) {
 				log.Infof("Pulse %d completed and saved", p.PulseNo)
 			}
 		} else {
-			go c.reloadData(ctx, p.PrevPulseNumber, p.PulseNo)
+			c.reloadData(ctx, p.PrevPulseNumber, p.PulseNo)
 			CurrentIncompletePulse.Set(float64(p.PrevPulseNumber))
 		}
 	}
@@ -110,7 +110,7 @@ func (c *Controller) pulseSequence(ctx context.Context) {
 					log.Info("no next saved pulse. skipping")
 					return
 				}
-				go c.reloadData(ctx, c.sequentialPulse.PulseNumber, toPulse.PrevPulseNumber)
+				c.reloadData(ctx, c.sequentialPulse.PulseNumber, toPulse.PrevPulseNumber)
 				return
 			}
 			if nextSequential.IsComplete {

--- a/etl/controller/pulsemaintainer.go
+++ b/etl/controller/pulsemaintainer.go
@@ -77,17 +77,19 @@ func eraseJetDropRegister(ctx context.Context, c *Controller, log log.Logger) {
 // pulseSequence check if we have spaces between pulses and rerequests this pulses
 func (c *Controller) pulseSequence(ctx context.Context) {
 	emptyPulse := models.Pulse{}
+	waitTime := time.Duration(c.cfg.SequentialPeriod)
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(time.Second * time.Duration(c.cfg.SequentialPeriod)):
+		case <-time.After(time.Second * waitTime):
 		}
 		var err error
 		var nextSequential models.Pulse
 		func() {
 			c.sequentialPulseLock.Lock()
 			defer c.sequentialPulseLock.Unlock()
+			waitTime = time.Duration(c.cfg.SequentialPeriod)
 			log := belogger.FromContext(ctx)
 			log = log.WithField("sequential_pulse", c.sequentialPulse)
 			CurrentSeqPulse.Set(float64(c.sequentialPulse.PulseNumber))
@@ -108,7 +110,7 @@ func (c *Controller) pulseSequence(ctx context.Context) {
 					log.Info("no next saved pulse. skipping")
 					return
 				}
-				c.reloadData(ctx, c.sequentialPulse.PulseNumber, toPulse.PrevPulseNumber)
+				go c.reloadData(ctx, c.sequentialPulse.PulseNumber, toPulse.PrevPulseNumber)
 				return
 			}
 			if nextSequential.IsComplete {
@@ -119,6 +121,7 @@ func (c *Controller) pulseSequence(ctx context.Context) {
 				}
 				c.sequentialPulse = nextSequential
 				log.Infof("Pulse %d sequenced", nextSequential.PulseNumber)
+				waitTime = time.Duration(0)
 				return
 			}
 		}()

--- a/etl/extractor/platform_impl.go
+++ b/etl/extractor/platform_impl.go
@@ -73,7 +73,7 @@ func (e *PlatformExtractor) GetJetDrops(ctx context.Context) <-chan *types.Platf
 }
 
 func (e *PlatformExtractor) LoadJetDrops(ctx context.Context, fromPulseNumber int64, toPulseNumber int64) error {
-	e.retrievePulses(ctx, fromPulseNumber, toPulseNumber)
+	go e.retrievePulses(ctx, fromPulseNumber, toPulseNumber)
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**
- raise timeout in unit test to 2h
- pause between setting sequential pulses is zero, if next pulse was successfully set to sequential. It allows to catch up to current pulse platform pulse faster.
- start goroutine for reload after it was added to missing data, in every places. It allow not wait for reloading batch of pulses in pulseSequence func and make reloaded pulses sequence one by one, not waiting for all pulses to reload. It also allowed to add reload interval to missedData component before lose control in reload func.

